### PR TITLE
Update search limits to avoid 500s

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,3 +7,6 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 ### Changed
 - Organized and updated documentation markdown docs [#11](https://github.com/microsoft/planetary-computer-apis/pull/11)
+
+### Fixed
+- Updated search limit constraints to avoid 500s [#15](https://github.com/microsoft/planetary-computer-apis/pull/15)

--- a/pcstac/pcstac/search.py
+++ b/pcstac/pcstac/search.py
@@ -11,7 +11,7 @@ DEFAULT_LIMIT = 250
 class PCSearch(PgstacSearch):
     # Increase the default limit for performance
     # Ignore "Illegal type annotation: call expression not allowed"
-    limit: Optional[conint(ge=0, le=10000)] = DEFAULT_LIMIT  # type:ignore
+    limit: Optional[conint(ge=1, le=1000)] = DEFAULT_LIMIT  # type:ignore
 
 
 @attr.s


### PR DESCRIPTION
## Description

This PR attempts to resolve two persistent issues:
1. a limit of 0 should issue a 400
2. extremely high limit values (e.g. 10000) issue a 500 based on response sizes being too large for the server

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

This has been run locally.

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [x] Changelog has been updated
- [x] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)