### PR TITLE
Set subscription explicitly during deploy

### DIFF
--- a/deployment/bin/lib
+++ b/deployment/bin/lib
@@ -56,7 +56,8 @@ function cluster_login() {
 
     az aks get-credentials \
         --resource-group ${RESOURCE_GROUP} \
-        --name ${CLUSTER_NAME}
+        --name ${CLUSTER_NAME} \
+        --subscription ${ARM_SUBSCRIPTION_ID}
 }
 
 function setup_helm() {


### PR DESCRIPTION
## Description

Previously some non-deterministic ordering of subscriptions was used,
resulting in transient RBAC errors for the SP using the wrong
subscription.

See: https://docs.microsoft.com/en-us/cli/azure/aks?view=azure-cli-latest#az_aks_get_credentials

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Needs to be tested in CI.