### PR TITLE
Restore default limit and gnatsgo render config

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,8 +22,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added endpoints to generate legends from colormap or registered classmaps [#17](https://github.com/microsoft/planetary-computer-apis/pull/17)
 - Configuration for chloris-biomass, nrcan-landcover, noaa-c-cap
 - Configuration for io-lulc-9-class [#34](https://github.com/microsoft/planetary-computer-apis/pull/34)
+- Configuration for gnatsgo [#36](https://github.com/microsoft/planetary-computer-apis/pull/36)
 
 ### Fixed
 
 - Updated search limit constraints to avoid 500s [#15](https://github.com/microsoft/planetary-computer-apis/pull/15)
 - Fixed STAC `describedby` and `preview` links [#33](https://github.com/microsoft/planetary-computer-apis/pull/33)
+- Default search limit restored to 250 [#36](https://github.com/microsoft/planetary-computer-apis/pull/36)

--- a/pccommon/render.py
+++ b/pccommon/render.py
@@ -110,6 +110,15 @@ COLLECTION_RENDER_CONFIG = {
         requires_token=False,
         minzoom=5,
     ),
+    "gnatsgo": DefaultRenderConfig(
+        create_links=False,
+        assets=["aws0-100"],
+        render_params={"colormap_name": "cividis"},
+        mosaic_preview_zoom=6,
+        mosaic_preview_coords=[44.1454, -112.6404],
+        requires_token=True,
+        minzoom=4,
+    ),
     "goes-mcmip": DefaultRenderConfig(
         create_links=True,  # Issues with colormap size, rendering
         assets=["data"],

--- a/pccommon/render.py
+++ b/pccommon/render.py
@@ -112,7 +112,7 @@ COLLECTION_RENDER_CONFIG = {
     ),
     "gnatsgo-rasters": DefaultRenderConfig(
         create_links=False,
-        assets=["aws0-100"],
+        assets=["aws0_100"],
         render_params={"colormap_name": "cividis"},
         mosaic_preview_zoom=6,
         mosaic_preview_coords=[44.1454, -112.6404],

--- a/pccommon/render.py
+++ b/pccommon/render.py
@@ -110,7 +110,7 @@ COLLECTION_RENDER_CONFIG = {
         requires_token=False,
         minzoom=5,
     ),
-    "gnatsgo": DefaultRenderConfig(
+    "gnatsgo-rasters": DefaultRenderConfig(
         create_links=False,
         assets=["aws0-100"],
         render_params={"colormap_name": "cividis"},

--- a/pcstac/pcstac/api.py
+++ b/pcstac/pcstac/api.py
@@ -1,11 +1,8 @@
 from typing import Any, Dict, Optional
 
 from stac_fastapi.api.app import StacApi
-from stac_fastapi.api.models import create_request_model
-from stac_pydantic import ItemCollection
 
 from pccommon.openapi import fixup_schema
-from pcstac.search import PCItemCollectionUri
 
 STAC_API_OPENAPI_TAG = "STAC API v1.0.0-beta.2"
 
@@ -26,30 +23,3 @@ class PCStacApi(StacApi):
         schema = super().customize_openapi()
         assert schema is not None
         return fixup_schema(self.app.root_path, schema, tag=STAC_API_OPENAPI_TAG)
-
-    # TODO: Allow overriding base_model for ItemCollectionUri upstream in stac-fastapi
-    def register_get_item_collection(self) -> None:
-        """Register get item collection endpoint (GET /collection/{collection_id}/items).
-        Returns:
-            None
-        """
-        get_pagination_model = self.get_extension(self.pagination_extension).GET
-        request_model = create_request_model(
-            "ItemCollectionURI",
-            base_model=PCItemCollectionUri,
-            mixins=[get_pagination_model],
-        )
-        self.router.add_api_route(
-            name="Get ItemCollection",
-            path="/collections/{collection_id}/items",
-            response_model=ItemCollection
-            if self.settings.enable_response_models
-            else None,
-            response_class=self.response_class,
-            response_model_exclude_unset=True,
-            response_model_exclude_none=True,
-            methods=["GET"],
-            endpoint=self._create_endpoint(
-                self.client.item_collection, request_model, self.response_class
-            ),
-        )

--- a/pcstac/pcstac/api.py
+++ b/pcstac/pcstac/api.py
@@ -1,8 +1,11 @@
 from typing import Any, Dict, Optional
 
 from stac_fastapi.api.app import StacApi
+from stac_fastapi.api.models import create_request_model
+from stac_pydantic import ItemCollection
 
 from pccommon.openapi import fixup_schema
+from pcstac.search import PCItemCollectionUri
 
 STAC_API_OPENAPI_TAG = "STAC API v1.0.0-beta.2"
 
@@ -23,3 +26,30 @@ class PCStacApi(StacApi):
         schema = super().customize_openapi()
         assert schema is not None
         return fixup_schema(self.app.root_path, schema, tag=STAC_API_OPENAPI_TAG)
+
+    # TODO: Allow overriding base_model for ItemCollectionUri upstream in stac-fastapi
+    def register_get_item_collection(self) -> None:
+        """Register get item collection endpoint (GET /collection/{collection_id}/items).
+        Returns:
+            None
+        """
+        get_pagination_model = self.get_extension(self.pagination_extension).GET
+        request_model = create_request_model(
+            "ItemCollectionURI",
+            base_model=PCItemCollectionUri,
+            mixins=[get_pagination_model],
+        )
+        self.router.add_api_route(
+            name="Get ItemCollection",
+            path="/collections/{collection_id}/items",
+            response_model=ItemCollection
+            if self.settings.enable_response_models
+            else None,
+            response_class=self.response_class,
+            response_model_exclude_unset=True,
+            response_model_exclude_none=True,
+            methods=["GET"],
+            endpoint=self._create_endpoint(
+                self.client.item_collection, request_model, self.response_class
+            ),
+        )

--- a/pcstac/pcstac/main.py
+++ b/pcstac/pcstac/main.py
@@ -29,7 +29,7 @@ from pcstac.api import PCStacApi
 from pcstac.client import PCClient
 from pcstac.config import API_DESCRIPTION, API_TITLE, API_VERSION, get_settings
 from pcstac.errors import PC_DEFAULT_STATUS_CODES
-from pcstac.search import PCSearch
+from pcstac.search import PCSearch, PCSearchGetRequest
 
 DEBUG: bool = os.getenv("DEBUG") == "TRUE" or False
 
@@ -79,7 +79,9 @@ collections_conformance_classes: List[str] = [
 
 extra_conformance_classes = cql_conformance_classes + collections_conformance_classes
 
-search_get_request_model = create_get_request_model(extensions)
+search_get_request_model = create_get_request_model(
+    extensions, base_model=PCSearchGetRequest
+)
 search_post_request_model = create_post_request_model(extensions, base_model=PCSearch)
 
 api = PCStacApi(

--- a/pcstac/tests/conftest.py
+++ b/pcstac/tests/conftest.py
@@ -24,7 +24,7 @@ from stac_fastapi.pgstac.db import close_db_connection, connect_to_db
 
 from pcstac.api import PCStacApi
 from pcstac.client import PCClient
-from pcstac.search import PCSearch
+from pcstac.search import PCSearch, PCSearchGetRequest
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
 
@@ -68,7 +68,9 @@ def api_client(pqe_pg):
         TokenPaginationExtension(),
         ContextExtension(),
     ]
-    search_get_request_model = create_get_request_model(extensions)
+    search_get_request_model = create_get_request_model(
+        extensions, base_model=PCSearchGetRequest
+    )
     search_post_request_model = create_post_request_model(
         extensions, base_model=PCSearch
     )

--- a/pcstac/tests/resources/test_item.py
+++ b/pcstac/tests/resources/test_item.py
@@ -300,7 +300,7 @@ async def test_item_search_get_query_extension(app_client):
     )
     resp = await app_client.get("/search", params=params)
     resp_json = resp.json()
-    assert len(resp_json["features"]) == 10
+    assert len(resp_json["features"]) == 12
     assert (
         resp_json["features"][0]["properties"]["proj:epsg"]
         == first_item["properties"]["proj:epsg"]
@@ -534,3 +534,29 @@ async def test_search_bbox_errors(app_client):
     params = {"bbox": "100.0,0.0,0.0,105.0"}
     resp = await app_client.get("/search", params=params)
     assert resp.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_items_page_limits(app_client):
+    resp = await app_client.get("/collections/naip/items")
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert len(resp_json["features"]) == 10
+
+
+@pytest.mark.asyncio
+async def test_search_get_page_limits(app_client):
+    resp = await app_client.get("/search?collection=naip")
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert len(resp_json["features"]) == 12
+
+
+@pytest.mark.asyncio
+async def test_search_post_page_limits(app_client):
+    params = {"op": "=", "args": [{"property": "collection"}, "naip"]}
+
+    resp = await app_client.post("/search", json=params)
+    assert resp.status_code == 200
+    resp_json = resp.json()
+    assert len(resp_json["features"]) == 12

--- a/scripts/test
+++ b/scripts/test
@@ -7,24 +7,58 @@ if [[ "${CI}" ]]; then
 fi
 
 function usage() {
+    if [[ "${1}" ]]; then
+        echo "${1}"
+    fi
     echo -n \
-        "Usage: $(basename "$0") [--dev, --db, --migrations, --deploy]
+        "Usage: $(basename "$0") [OPTIONS]
 Runs tests for the project.
 
+Options
+    --stac
+        Only test pcstac
+    --tiler
+        Only test pctiler
 "
 }
 
-if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
-    docker-compose \
-        -f docker-compose.yml \
-        -f docker-compose.dev.yml \
-        run --rm \
-        tiler-dev scripts/bin/test-tiler
+# Parse args
+while [[ $# -gt 0 ]]; do case $1 in
+    --stac)
+        STAC_ONLY="1"
+        shift
+        ;;
+    --tiler)
+        TILER_ONLY="1"
+        shift
+        ;;
+    --help)
+        usage
+        exit 0
+        shift
+        ;;
+    *)
+        usage "Unknown parameter passed: $1"
+        exit 1
+        ;;
+    esac done
 
-    docker-compose \
-        -f docker-compose.yml \
-        -f docker-compose.dev.yml \
-        run --rm \
-        stac-dev scripts/bin/test-stac
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+    if [ -z ${STAC_ONLY} ]; then
+        docker-compose \
+            -f docker-compose.yml \
+            -f docker-compose.dev.yml \
+            run --rm \
+            tiler-dev scripts/bin/test-tiler
+    fi
+
+    if [ -z ${TILER_ONLY} ]; then
+
+        docker-compose \
+            -f docker-compose.yml \
+            -f docker-compose.dev.yml \
+            run --rm \
+            stac-dev scripts/bin/test-stac
+    fi
 
 fi


### PR DESCRIPTION
## Description

- Adds gnatsgo render configuration
- Restores PC default limit of 250 items in response of GET searches and collection item path queries.
## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Tests pass and manual searches GET, POST, and items/ all return 250 results by default.

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [x] Changelog has been updated
- [ ] Documentation has been updated
- [x] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)