### PR TITLE
Fix conformance classes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+- Fixed conformance classes [#39](https://github.com/microsoft/planetary-computer-apis/pull/39)
+- Fixed STAC API version in API documentation [#39](https://github.com/microsoft/planetary-computer-apis/pull/39)
+
 ## [2022.1.0]
 
 ### Changed

--- a/pcstac/pcstac/api.py
+++ b/pcstac/pcstac/api.py
@@ -5,7 +5,7 @@ from stac_fastapi.api.app import StacApi
 from pccommon.openapi import fixup_schema
 from pcstac.config import STAC_API_VERSION
 
-STAC_API_OPENAPI_TAG = "STAC API v1.0.0-beta.2"
+STAC_API_OPENAPI_TAG = f"STAC API {STAC_API_VERSION}"
 
 
 class PCStacApi(StacApi):

--- a/pcstac/pcstac/api.py
+++ b/pcstac/pcstac/api.py
@@ -3,6 +3,7 @@ from typing import Any, Dict, Optional
 from stac_fastapi.api.app import StacApi
 
 from pccommon.openapi import fixup_schema
+from pcstac.config import STAC_API_VERSION
 
 STAC_API_OPENAPI_TAG = "STAC API v1.0.0-beta.2"
 

--- a/pcstac/pcstac/config.py
+++ b/pcstac/pcstac/config.py
@@ -12,6 +12,7 @@ from stac_fastapi.extensions.core import (
 from stac_fastapi.extensions.core.filter.filter import FilterConformanceClasses
 
 API_VERSION = "1.1"
+STAC_API_VERSION = "v1.0.0-beta.4"
 
 API_LANDING_PAGE_ID = "microsoft-pc"
 API_TITLE = "Microsoft Planetary Computer STAC API"

--- a/pcstac/pcstac/config.py
+++ b/pcstac/pcstac/config.py
@@ -2,6 +2,14 @@ import os
 from functools import lru_cache
 
 from pydantic import BaseSettings
+from stac_fastapi.extensions.core import (
+    FieldsExtension,
+    FilterExtension,
+    QueryExtension,
+    SortExtension,
+    TokenPaginationExtension,
+)
+from stac_fastapi.extensions.core.filter.filter import FilterConformanceClasses
 
 API_VERSION = "1.1"
 
@@ -11,16 +19,25 @@ API_DESCRIPTION = (
     "Searchable spatiotemporal metadata describing Earth science datasets "
     "hosted by the Microsoft Planetary Computer"
 )
-API_CONFORMANCE_CLASSES = [
-    "https://api.stacspec.org/v1.0.0-beta.3/core",
-    "https://api.stacspec.org/v1.0.0-beta.3/item-search",
-    "https://api.stacspec.org/v1.0.0-beta.3/item-search#query",
-    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/core",
-    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
-    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/geojson",
-]
 
 TILER_HREF_ENV_VAR = "TILER_HREF"
+
+EXTENSIONS = [
+    # STAC API Extensions
+    QueryExtension(),
+    SortExtension(),
+    FieldsExtension(),
+    FilterExtension(
+        conformance_classes=[
+            FilterConformanceClasses.FILTER,
+            FilterConformanceClasses.ITEM_SEARCH_FILTER,
+            FilterConformanceClasses.BASIC_CQL,
+            FilterConformanceClasses.CQL_JSON,
+        ]
+    ),
+    # stac_fastapi extensions
+    TokenPaginationExtension(),
+]
 
 
 class Settings(BaseSettings):

--- a/pcstac/pcstac/config.py
+++ b/pcstac/pcstac/config.py
@@ -11,7 +11,7 @@ from stac_fastapi.extensions.core import (
 )
 from stac_fastapi.extensions.core.filter.filter import FilterConformanceClasses
 
-API_VERSION = "1.1"
+API_VERSION = "1.2"
 STAC_API_VERSION = "v1.0.0-beta.4"
 
 API_LANDING_PAGE_ID = "microsoft-pc"
@@ -61,7 +61,7 @@ class Settings(BaseSettings):
     tiler_href: str = os.environ.get("TILER_HREF_ENV_VAR", "")
     openapi_url: str = "/openapi.json"
     debug: bool = os.getenv("PQE_DEBUG", "False").lower() == "true"
-    api_version: str = "v1.1"
+    api_version: str = f"v{API_VERSION}"
 
 
 @lru_cache

--- a/pcstac/pcstac/main.py
+++ b/pcstac/pcstac/main.py
@@ -1,7 +1,7 @@
 """FastAPI application using PGStac."""
 import logging
 import os
-from typing import Any, Awaitable, Callable, Dict, List
+from typing import Any, Awaitable, Callable, Dict
 
 from fastapi import FastAPI, Request, Response
 from fastapi.exceptions import RequestValidationError, StarletteHTTPException
@@ -9,14 +9,6 @@ from fastapi.openapi.utils import get_openapi
 from fastapi.responses import ORJSONResponse
 from stac_fastapi.api.errors import DEFAULT_STATUS_CODES
 from stac_fastapi.api.models import create_get_request_model, create_post_request_model
-from stac_fastapi.extensions.core import (
-    ContextExtension,
-    FieldsExtension,
-    FilterExtension,
-    QueryExtension,
-    SortExtension,
-    TokenPaginationExtension,
-)
 from stac_fastapi.pgstac.config import Settings
 from stac_fastapi.pgstac.db import close_db_connection, connect_to_db
 from starlette.middleware.cors import CORSMiddleware
@@ -27,7 +19,13 @@ from pccommon.middleware import RequestTracingMiddleware, handle_exceptions
 from pccommon.openapi import fixup_schema
 from pcstac.api import PCStacApi
 from pcstac.client import PCClient
-from pcstac.config import API_DESCRIPTION, API_TITLE, API_VERSION, get_settings
+from pcstac.config import (
+    API_DESCRIPTION,
+    API_TITLE,
+    API_VERSION,
+    EXTENSIONS,
+    get_settings,
+)
 from pcstac.errors import PC_DEFAULT_STATUS_CODES
 from pcstac.search import PCSearch, PCSearchGetRequest
 
@@ -47,53 +45,19 @@ logger.info(f"INCLUDE_TRANSACTIONS: {INCLUDE_TRANSACTIONS}")
 POOL_SIZE = int(os.environ.get("POOL_SIZE", "1"))
 logger.info(f"POOL_SIZE: {POOL_SIZE}")
 
-extensions = [
-    QueryExtension(),
-    SortExtension(),
-    FieldsExtension(),
-    FilterExtension(),
-    TokenPaginationExtension(),
-    ContextExtension(),
-]
-
-# Planetary Computer conformance classes differ from the default
-# stac-fastapi case so they are manually specified
-cql_conformance_classes: List[str] = [
-    "https://api.stacspec.org/v1.0.0-beta.3/item-search/#fields",
-    "https://api.stacspec.org/v1.0.0-beta.3/item-search#filter",
-    "https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:cql-json",
-    "https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:filter",
-    "https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:item-search-filter",
-    "https://api.stacspec.org/v1.0.0-beta.3/item-search#filter:basic-spatial-operators",
-    (
-        "https://api.stacspec.org/v1.0.0-beta.3/item-search"
-        "#filter:basic-temporal-operators"
-    ),
-    "https://api.stacspec.org/v1.0.0-beta.3/item-search/#sort",
-    "https://api.stacspec.org/v1.0.0-beta.3/item-search/#query",
-]
-
-collections_conformance_classes: List[str] = [
-    "http://www.opengis.net/spec/ogcapi-features-1/1.0/conf/oas30",
-]
-
-extra_conformance_classes = cql_conformance_classes + collections_conformance_classes
 
 search_get_request_model = create_get_request_model(
-    extensions, base_model=PCSearchGetRequest
+    EXTENSIONS, base_model=PCSearchGetRequest
 )
-search_post_request_model = create_post_request_model(extensions, base_model=PCSearch)
+search_post_request_model = create_post_request_model(EXTENSIONS, base_model=PCSearch)
 
 api = PCStacApi(
     title=API_TITLE,
     description=API_DESCRIPTION,
     api_version=API_VERSION,
     settings=Settings(debug=DEBUG),
-    client=PCClient.create(
-        post_request_model=search_post_request_model,
-        extra_conformance_classes=extra_conformance_classes,
-    ),
-    extensions=extensions,
+    client=PCClient.create(post_request_model=search_post_request_model),
+    extensions=EXTENSIONS,
     app=FastAPI(root_path=APP_ROOT_PATH, default_response_class=ORJSONResponse),
     search_get_request_model=search_get_request_model,
     search_post_request_model=search_post_request_model,

--- a/pcstac/tests/conftest.py
+++ b/pcstac/tests/conftest.py
@@ -11,19 +11,12 @@ from fastapi.responses import ORJSONResponse
 from httpx import AsyncClient
 from pypgstac import pypgstac
 from stac_fastapi.api.models import create_get_request_model, create_post_request_model
-from stac_fastapi.extensions.core import (
-    ContextExtension,
-    FieldsExtension,
-    FilterExtension,
-    QueryExtension,
-    SortExtension,
-    TokenPaginationExtension,
-)
 from stac_fastapi.pgstac.config import Settings
 from stac_fastapi.pgstac.db import close_db_connection, connect_to_db
 
 from pcstac.api import PCStacApi
 from pcstac.client import PCClient
+from pcstac.config import EXTENSIONS
 from pcstac.search import PCSearch, PCSearchGetRequest
 
 DATA_DIR = os.path.join(os.path.dirname(__file__), "data")
@@ -60,19 +53,11 @@ async def pqe_pg():
 @pytest.fixture(scope="session")
 def api_client(pqe_pg):
     print("creating client with settings", settings, settings.reader_connection_string)
-    extensions = [
-        QueryExtension(),
-        SortExtension(),
-        FilterExtension(),
-        FieldsExtension(),
-        TokenPaginationExtension(),
-        ContextExtension(),
-    ]
     search_get_request_model = create_get_request_model(
-        extensions, base_model=PCSearchGetRequest
+        EXTENSIONS, base_model=PCSearchGetRequest
     )
     search_post_request_model = create_post_request_model(
-        extensions, base_model=PCSearch
+        EXTENSIONS, base_model=PCSearch
     )
     api = PCStacApi(
         title="test title",
@@ -82,7 +67,7 @@ def api_client(pqe_pg):
         client=PCClient.create(
             post_request_model=search_post_request_model,
         ),
-        extensions=extensions,
+        extensions=EXTENSIONS,
         app=FastAPI(default_response_class=ORJSONResponse),
         search_get_request_model=search_get_request_model,
         search_post_request_model=search_post_request_model,


### PR DESCRIPTION
## Description

The upgrade to stac_fastapi, which included a change in how conformance classes were calculated, caused some code we had to manually define conformance classes to produce duplicate classes from two different STAC API versions.

These changes use the new stac_fastapi mechanism and default conformances classes, which produce the correct set. The default Filter extension conformance classes are modified to remove `cql-text`, which we do not yet support, which [coming soon!](https://github.com/geopython/pygeofilter/pull/41)

Test were added to catch if conformance classes are of an incorrect STAC API version. This would have caught this issue, which resulted in two of the same conformances classes with the only difference being the STAC version.

Additionally, the advertised STAC API version advertised on the [api docs](https://planetarycomputer.microsoft.com/api/stac/v1/docs) was updated and set to use the single configured STAC_API_VERSION.

The API version that is found in the OpenAPI docs was moved from 1.1 to 1.2

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Viewing the conformances classes produced in the landing page of the development server and unit tests.

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [x] Changelog has been updated
- [x] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)