### PR TITLE
Fix generated tiler links in items

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
+## [2022.1.2]
+
+### Fixed
+
+- Fixed renderconfigs for item tile links [#41](https://github.com/microsoft/planetary-computer-apis/pull/41)
+- Fixes hostname setting for URLs used in item links
+
 ## [2022.1.1]
 
 ### Fixed

--- a/pccommon/render.py
+++ b/pccommon/render.py
@@ -18,9 +18,9 @@ class DefaultRenderConfig:
     normal human vision, parameters will likely encode this rendering.
     """
 
-    assets: List[str]
     render_params: Dict[str, Any]
     minzoom: int
+    assets: Optional[List[str]] = None
     maxzoom: Optional[int] = 18
     create_links: bool = True
     has_mosaic: bool = False
@@ -29,8 +29,14 @@ class DefaultRenderConfig:
     requires_token: bool = False
     hidden: bool = False  # Hide from API
 
-    def get_assets_param(self) -> str:
-        return ",".join(self.assets)
+    def get_assets_params(self) -> str:
+        if self.assets is None:
+            return ""
+
+        if len(self.assets) == 1:
+            return f"&assets={self.assets[0]}"
+
+        return "&assets=".join(self.assets)
 
     def get_render_params(self) -> str:
         return get_param_str(self.render_params)
@@ -72,7 +78,7 @@ COLLECTION_RENDER_CONFIG = {
     ),
     "aster-l1t": DefaultRenderConfig(
         assets=["VNIR"],
-        render_params={"bidx": [2, 3, 1], "nodata": 0},
+        render_params={"asset_bidx": "VNIR|2,3,1", "nodata": 0},
         mosaic_preview_zoom=9,
         mosaic_preview_coords=[37.2141, -104.2947],
         minzoom=9,
@@ -111,9 +117,8 @@ COLLECTION_RENDER_CONFIG = {
         minzoom=5,
     ),
     "gnatsgo-rasters": DefaultRenderConfig(
-        create_links=False,
         assets=["aws0_100"],
-        render_params={"colormap_name": "cividis"},
+        render_params={"colormap_name": "cividis", "rescale": [0, 600]},
         mosaic_preview_zoom=6,
         mosaic_preview_coords=[44.1454, -112.6404],
         requires_token=True,
@@ -130,7 +135,6 @@ COLLECTION_RENDER_CONFIG = {
     ),
     "goes-cmi": DefaultRenderConfig(
         create_links=True,
-        assets=["data"],
         render_params={
             "expression": (
                 "C02_2km_wm,"
@@ -212,7 +216,7 @@ COLLECTION_RENDER_CONFIG = {
     ),
     "naip": DefaultRenderConfig(
         assets=["image"],
-        render_params={"bidx": [1, 2, 3]},
+        render_params={"asset_bidx": "image|1,2,3"},
         mosaic_preview_zoom=13,
         mosaic_preview_coords=[36.0891, -111.8577],
         minzoom=11,
@@ -235,7 +239,7 @@ COLLECTION_RENDER_CONFIG = {
     ),
     "sentinel-2-l2a": DefaultRenderConfig(
         assets=["visual"],
-        render_params={"bidx": [1, 2, 3], "nodata": 0},
+        render_params={"asset_bidx": "visual|1,2,3", "nodata": 0},
         mosaic_preview_zoom=9,
         mosaic_preview_coords=[-16.4940, 124.0274],
         requires_token=True,

--- a/pcstac/pcstac/tiles.py
+++ b/pcstac/pcstac/tiles.py
@@ -58,7 +58,7 @@ class TileInfo:
             (
                 "collection/tilejson.json?"
                 f"collection={self.collection_id}"
-                f"&assets={self.render_config.get_assets_param()}"
+                f"{self.render_config.get_assets_params()}"
                 f"{render_params_part}"
             ),
         )
@@ -91,8 +91,8 @@ class TileInfo:
             (
                 f"item/preview.png?"
                 f"collection={self.collection_id}"
-                f"&items={item_id}"
-                f"&assets={self.render_config.get_assets_param()}"
+                f"&item={item_id}"
+                f"{self.render_config.get_assets_params()}"
                 f"{render_params_part}"
             ),
         )
@@ -113,8 +113,8 @@ class TileInfo:
             (
                 "item/tilejson.json?"
                 f"collection={self.collection_id}"
-                f"&items={item_id}"
-                f"&assets={self.render_config.get_assets_param()}"
+                f"&item={item_id}"
+                f"{self.render_config.get_assets_params()}"
                 f"{render_params_part}"
             ),
         )

--- a/pctiler/pctiler/endpoints/item.py
+++ b/pctiler/pctiler/endpoints/item.py
@@ -5,7 +5,6 @@ from fastapi import Query, Request, Response
 from fastapi.templating import Jinja2Templates
 from starlette.responses import HTMLResponse
 from titiler.core.factory import MultiBaseTilerFactory
-from pccommon import render
 
 from pccommon.render import COLLECTION_RENDER_CONFIG
 from pccommon.utils import get_param_str

--- a/pctiler/pctiler/endpoints/item.py
+++ b/pctiler/pctiler/endpoints/item.py
@@ -5,6 +5,7 @@ from fastapi import Query, Request, Response
 from fastapi.templating import Jinja2Templates
 from starlette.responses import HTMLResponse
 from titiler.core.factory import MultiBaseTilerFactory
+from pccommon import render
 
 from pccommon.render import COLLECTION_RENDER_CONFIG
 from pccommon.utils import get_param_str
@@ -51,12 +52,15 @@ def map(
             content=f"No item map available for collection {collection}",
         )
 
-    tilejson_params = get_param_str(
-        {
-            "collection": collection,
-            "item": item,
-            "assets": ",".join(render_config.assets),
-        }
+    tilejson_params = (
+        get_param_str(
+            {
+                "collection": collection,
+                "item": item,
+            }
+        )
+        + render_config.get_assets_params()
+        + f"&{render_config.get_render_params()}"
     )
 
     tilejson_url = pc_tile_factory.url_for(request, "tilejson")
@@ -75,6 +79,5 @@ def map(
             "collectionId": collection,
             "itemId": item,
             "itemUrl": item_url,
-            "renderParams": get_param_str(render_config.render_params),
         },
     )

--- a/pctiler/templates/item_preview.html
+++ b/pctiler/templates/item_preview.html
@@ -28,10 +28,6 @@
                 ).addTo(map);
 
                 var tiles = tileJson.tiles[0];
-                var renderParams = "{{ renderParams }}";
-                if (renderParams) {
-                    tiles += "&" + renderParams;
-                }
 
                 var tileLayer = L.tileLayer(tiles, {
                     minZoom: tileJson.minzoon,


### PR DESCRIPTION
## Description

Matches TiTiler param patterns and fixes some misconfigured render params. Notably, allows `expression` to be included in tilejson requests to support goes-cmi

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Local preview, rendered_preview, and tilejson generation for a number of collections

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [x] Changelog has been updated
- [ ] Documentation has been updated
- [x] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)