### PR TITLE
Implement queryables through proxy to online json files

### DIFF
--- a/pcstac/pcstac/config.py
+++ b/pcstac/pcstac/config.py
@@ -37,7 +37,7 @@ EXTENSIONS = [
             FilterConformanceClasses.ITEM_SEARCH_FILTER,
             FilterConformanceClasses.BASIC_CQL,
             FilterConformanceClasses.CQL_JSON,
-        ]
+        ],
     ),
     # stac_fastapi extensions
     TokenPaginationExtension(),

--- a/pcstac/pcstac/config.py
+++ b/pcstac/pcstac/config.py
@@ -11,6 +11,8 @@ from stac_fastapi.extensions.core import (
 )
 from stac_fastapi.extensions.core.filter.filter import FilterConformanceClasses
 
+from pcstac.filter import MSPCFiltersClient
+
 API_VERSION = "1.2"
 STAC_API_VERSION = "v1.0.0-beta.4"
 
@@ -29,6 +31,7 @@ EXTENSIONS = [
     SortExtension(),
     FieldsExtension(),
     FilterExtension(
+        client=MSPCFiltersClient(),
         conformance_classes=[
             FilterConformanceClasses.FILTER,
             FilterConformanceClasses.ITEM_SEARCH_FILTER,

--- a/pcstac/pcstac/filter.py
+++ b/pcstac/pcstac/filter.py
@@ -1,0 +1,24 @@
+from typing import Any, Dict, Optional
+
+import requests
+
+from stac_fastapi.types.core import AsyncBaseFiltersClient
+
+class MSPCFiltersClient(AsyncBaseFiltersClient):
+    """Defines a pattern for implementing the STAC filter extension."""
+
+    async def get_queryables(
+        self, collection_id: Optional[str] = None, **kwargs
+    ) -> Dict[str, Any]:
+        """Get the queryables available for the given collection_id.
+        If collection_id is None, returns the intersection of all
+        queryables over all collections.
+        This base implementation returns a blank queryable schema. This is not allowed
+        under OGC CQL but it is allowed by the STAC API Filter Extension
+        https://github.com/radiantearth/stac-api-spec/tree/master/fragments/filter#queryables
+        """
+        if not collection_id:
+            return await super().get_queryables(collection_id, **kwargs)
+        else:
+            r = requests.get(f"https://planetarycomputer.microsoft.com/stac/{collection_id}/queryables.json")
+            return r.json()

--- a/pcstac/pcstac/filter.py
+++ b/pcstac/pcstac/filter.py
@@ -4,6 +4,7 @@ import requests
 
 from stac_fastapi.types.core import AsyncBaseFiltersClient
 
+
 class MSPCFiltersClient(AsyncBaseFiltersClient):
     """Defines a pattern for implementing the STAC filter extension."""
 
@@ -20,5 +21,7 @@ class MSPCFiltersClient(AsyncBaseFiltersClient):
         if not collection_id:
             return await super().get_queryables(collection_id, **kwargs)
         else:
-            r = requests.get(f"https://planetarycomputer.microsoft.com/stac/{collection_id}/queryables.json")
+            r = requests.get(
+                f"https://planetarycomputer.microsoft.com/stac/{collection_id}/queryables.json"
+            )
             return r.json()


### PR DESCRIPTION
## Description

This PR adds support for per-collection queryables which will, for now, be proxied from `https://planetarycomputer.microsoft.com/stac/{collection}/queryables.json`.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

TODO

## Checklist:

Please delete options that are not relevant.

- [ ] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [ ] Code is linted and styled (./scripts/format)