### PR TITLE
New titiler pgstac

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- Update titiler-pgstac version to `0.1.0.a4` in `pctiler` (https://github.com/microsoft/planetary-computer-apis/pull/46)
+
 ### Added
 
 ### Fixed

--- a/pctiler/setup.py
+++ b/pctiler/setup.py
@@ -16,7 +16,7 @@ inst_reqs = [
 
     # titiler-pgstac
     "psycopg[binary,pool]",
-    "titiler.pgstac==0.1.0a3",
+    "titiler.pgstac==0.1.0a4",
 
     # colormap dependencies
     "matplotlib==3.4.*",


### PR DESCRIPTION
## Description

This PR update the `titiler-pgstac` version requirement used in pctiler (adds `buffer` option to the tile endpoints)