### PR TITLE
Upgrade to Jinja2 v3

### DIFF
--- a/pctiler/setup.py
+++ b/pctiler/setup.py
@@ -5,7 +5,7 @@ from setuptools import find_packages, setup
 # Runtime requirements.
 inst_reqs = [
     "geojson-pydantic==0.3.1",
-    "jinja2==2.11.3",
+    "jinja2==3.0.3",
     "pystac==1.*",
     "planetary-computer==0.4.*",
 


### PR DESCRIPTION
## Description

Fixes dependency issues in downstream projects. Jinja2 is unsupported
and currently broken. As a result, the tiler project would throw on startup.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

In the tiler serveice, templates are used for the item_preview endpoint. The item_preview endpoint is generated correctly under this version of Jinja2

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [x] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)