### PR TITLE
Upgrade to supported k8s version in staging

### DIFF
--- a/deployment/terraform/staging/main.tf
+++ b/deployment/terraform/staging/main.tf
@@ -4,7 +4,7 @@ module "resources" {
   environment = "staging"
   region = "West Europe"
 
-  k8s_version = "1.20.7"
+  k8s_version = "1.22.6"
 
   cluster_cert_issuer = "letsencrypt"
   cluster_cert_server = "https://acme-v02.api.letsencrypt.org/directory"


### PR DESCRIPTION
## Description

The staging cluster was recently destroyed for debugging and the new instance needed to be upgraded to supporting version.