### PR TITLE
Fix PCT tiler signing

### DIFF
--- a/deployment/helm/deploy-values.template.yaml
+++ b/deployment/helm/deploy-values.template.yaml
@@ -61,7 +61,8 @@ tiler:
 
   stac_api_url: http://planetary-computer-stac.pc.svc.cluster.local
   stac_api_href: https://{{ tf.dns_label }}.westeurope.cloudapp.azure.com/stac/
-  pc_sdk_sas_url: https://{{ tf.dns_label }}.westeurope.cloudapp.azure.com/sas/
+  # PCT sas needs to be accessed through api management
+  pc_sdk_sas_url: https://pct-sas-westeurope-staging-apim.azure-api.net/sas/token
 
 metrics:
   instrumentationKey: "{{ tf.instrumentation_key }}"

--- a/deployment/helm/deploy-values.template.yaml
+++ b/deployment/helm/deploy-values.template.yaml
@@ -13,13 +13,13 @@ stac:
     poolSize: "1"
 
   storage:
-    account_name: {{ tf.storage_account_name }}
-    account_key: {{ tf.storage_account_key }}
-    collection_config_table_name: {{ tf.collection_config_table_name }}
-    container_config_table_name: {{ tf.container_config_table_name }}
+    account_name: "{{ tf.storage_account_name }}"
+    account_key: "{{ tf.storage_account_key }}"
+    collection_config_table_name: "{{ tf.collection_config_table_name }}"
+    container_config_table_name: "{{ tf.container_config_table_name }}"
 
   deploy:
-    replicaCount: {{ tf.stac_replica_count }}
+    replicaCount: "{{ tf.stac_replica_count }}"
     podAnnotations:
       "pc/gitsha": "{{ env.GIT_COMMIT }}"
 
@@ -46,13 +46,13 @@ tiler:
     webConcurrency: "1"
 
   storage:
-    account_name: {{ tf.storage_account_name }}
-    account_key: {{ tf.storage_account_key }}
-    collection_config_table_name: {{ tf.collection_config_table_name }}
-    container_config_table_name: {{ tf.container_config_table_name }}
+    account_name: "{{ tf.storage_account_name }}"
+    account_key: "{{ tf.storage_account_key }}"
+    collection_config_table_name: "{{ tf.collection_config_table_name }}"
+    container_config_table_name: "{{ tf.container_config_table_name }}"
 
   deploy:
-    replicaCount: {{ tf.tiler_replica_count }}
+    replicaCount: "{{ tf.tiler_replica_count }}"
     podAnnotations:
       "pc/gitsha": "{{ env.GIT_COMMIT }}"
 


### PR DESCRIPTION
## Description

Use the correct href for PCT environment SAS token endpoint. The PCT tiler uses this value to sign assets to read, and was previously failing.


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

The value provided here has been deployed to planetarycomputer-test to ensure it is correct. 

[See tiles working](https://planetarycomputer-test.microsoft.com/explore?c=-96.9497%2C36.6689&z=2.45&r=Aboveground+Biomass+%28tonnes%29&d=chloris-biomass&m=All+years)

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [x] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)