### PR TITLE
Lower cache TTLs for dev and PCT

### DIFF
--- a/deployment/helm/deploy-values.template.yaml
+++ b/deployment/helm/deploy-values.template.yaml
@@ -82,11 +82,13 @@ storage:
   collection_config_table_name: "{{ tf.collection_config_table_name }}"
   container_config_table_name: "{{ tf.container_config_table_name }}"
   ip_exception_config_table_name: "{{ tf.ip_exception_config_table_name }}"
+  table_value_ttl: 1
 
 redis:
   host: "{{ tf.redis_host }}"
   password: "{{ tf.redis_password }}"
   port: "{{ tf.redis_port }}"
+  ttl: 60
   ssl: true
 
 metrics:

--- a/deployment/helm/published/planetary-computer-stac/templates/deployment.yaml
+++ b/deployment/helm/published/planetary-computer-stac/templates/deployment.yaml
@@ -107,6 +107,8 @@ spec:
               value: "{{ .Values.redis.port }}"
             - name: "PCAPIS_REDIS_SSL"
               value: "{{ .Values.redis.ssl }}"
+            - name: "PCAPIS_REDIS_TTL"
+              value: "{{ .Values.redis.ttl }}"
             - name: "PCAPIS_RATE_LIMITS__COLLECTIONS"
               value: "{{ .Values.stac.rate_limit.collections }}"
             - name: "PCAPIS_RATE_LIMITS__COLLECTION"
@@ -137,6 +139,8 @@ spec:
               value: "{{ .Values.stac.back_pressure.search.req_per_sec }}"
             - name: "PCAPIS_BACK_PRESSURES__SEARCH__INC_MS"
               value: "{{ .Values.stac.back_pressure.search.inc_ms }}"
+            - name: "PCAPIS_TABLE_VALUE_TTL"
+              value: "{{ .Values.storage.table_value_ttl }}"
             - name: APP_INSIGHTS_INSTRUMENTATION_KEY
               value: "{{ .Values.metrics.instrumentationKey }}"
 

--- a/deployment/helm/published/planetary-computer-stac/values.yaml
+++ b/deployment/helm/published/planetary-computer-stac/values.yaml
@@ -77,12 +77,14 @@ storage:
   collection_config_table_name: ""
   container_config_table_name: ""
   ip_exception_config_table_name: ""
+  table_value_ttl: 600
 
 redis:
   host: ""
   password: ""
   port: 6380
   ssl: true
+  ttl: 600
 
 metrics:
   instrumentationKey: ""

--- a/deployment/helm/published/planetary-computer-tiler/templates/deployment.yaml
+++ b/deployment/helm/published/planetary-computer-tiler/templates/deployment.yaml
@@ -97,6 +97,8 @@ spec:
               value: "{{ .Values.storage.account_key }}"
             - name: "PCAPIS_IP_EXCEPTION_CONFIG__TABLE_NAME"
               value: "{{ .Values.storage.ip_exception_config_table_name }}"
+            - name: "PCAPIS_TABLE_VALUE_TTL"
+              value: "{{ .Values.storage.table_value_ttl }}"
             - name: "PCAPIS_REDIS_HOSTNAME"
               value: "{{ .Values.redis.host }}"
             - name: "PCAPIS_REDIS_PASSWORD"
@@ -105,6 +107,8 @@ spec:
               value: "{{ .Values.redis.port }}"
             - name: "PCAPIS_REDIS_SSL"
               value: "{{ .Values.redis.ssl }}"
+            - name: "PCAPIS_REDIS_TTL"
+              value: "{{ .Values.redis.ttl }}"
             - name: APP_INSIGHTS_INSTRUMENTATION_KEY
               value: "{{ .Values.metrics.instrumentationKey }}"
 

--- a/deployment/helm/published/planetary-computer-tiler/values.yaml
+++ b/deployment/helm/published/planetary-computer-tiler/values.yaml
@@ -47,12 +47,14 @@ storage:
   collection_config_table_name: ""
   container_config_table_name: ""
   ip_exception_config_table_name: ""
+  table_value_ttl: 600
 
 redis:
   host: ""
   password: ""
   port: 6380
   ssl: true
+  ttl: 600
 
 postgres:
   serverName: ""

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,6 +29,10 @@ services:
       - PCAPIS_IP_EXCEPTION_CONFIG__ACCOUNT_KEY=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
       - PCAPIS_IP_EXCEPTION_CONFIG__TABLE_NAME=ipexceptionlist
 
+      # Disable config and stac caching in development by setting TTL to 1 second
+      - PCAPIS_TABLE_VALUE_TTL=1
+      - PCAPIS_REDIS_TTL=1
+
       # Redis
       - PCAPIS_REDIS_HOSTNAME=redis
       - PCAPIS_REDIS_PASSWORD=devcache
@@ -132,6 +136,10 @@ services:
       - PCAPIS_IP_EXCEPTION_CONFIG__ACCOUNT_NAME=devstoreaccount1
       - PCAPIS_IP_EXCEPTION_CONFIG__ACCOUNT_KEY=Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw==
       - PCAPIS_IP_EXCEPTION_CONFIG__TABLE_NAME=ipexceptionlist
+
+      # Disable config and stac caching in development by setting TTL to 1 second
+      - PCAPIS_TABLE_VALUE_TTL=1
+      - PCAPIS_REDIS_TTL=1
 
       # Redis
       - PCAPIS_REDIS_HOSTNAME=redis


### PR DESCRIPTION
## Description

TTL for table config and redis cached values is reduced to 1 second in
local development environment to prevent stale values returning during
development. In PCT environments, the table config TTL is also reduced
to 1 second to support faster iteration on config in the test
environment. The PCT redis TTL was lowered to 1 minute to still provide some
efficiency during test, but to lower the time to wait for new
items/collections to show up that were previously cached, as that a main
use case of the environment. Default values remain the same, so
staging/prod are not affected, but can now be set at a target, rather
than default, value.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

Manual testing in local dev and PCT dev stack

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [x] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)