### PR TITLE
Bind tiler process to APP_HOST

### DIFF
--- a/pctiler/Dockerfile
+++ b/pctiler/Dockerfile
@@ -36,4 +36,4 @@ ENV MOSAIC_CONCURRENCY 1
 
 ENV APP_HOST=0.0.0.0
 ENV APP_PORT=80
-CMD uvicorn pctiler.main:app --host ${HOST} --port ${PORT} --log-level info
+CMD uvicorn pctiler.main:app --host ${APP_HOST} --port ${APP_PORT} --log-level info


### PR DESCRIPTION
## Description

APP_HOST and APP_PORT were lost in a recent refactor and caused issues
starting up the process in a Kubernetes environment.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [x] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)