### PR TITLE
Reregister redis lua scripts if missing

### DIFF
--- a/pcstac/tests/test_rate_limit.py
+++ b/pcstac/tests/test_rate_limit.py
@@ -34,3 +34,31 @@ async def test_rate_limit_collection_ip_Exception(app_client: AsyncClient):
     for _ in range(0, 400):
         resp = await app_client.get("/collections/naip")
         assert resp.status_code == 200
+
+
+@pytest.mark.asyncio
+async def test_reregistering_rate_limit_script(app: FastAPI, app_client: AsyncClient):
+    # set the ip to one that doesn't have the rate limit exception
+    async with AsyncClient(
+        app=app, base_url="http://test", headers={"X-Forwarded-For": "127.0.0.2"}
+    ) as app_client:
+
+        async def _hash_exists():
+            exists = await app.state.redis.script_exists(
+                app.state.redis_rate_limit_script_hash
+            )
+            return exists[0]
+
+        # Script is registered and requests should succeed
+        assert await _hash_exists()
+        resp = await app_client.get("/collections/naip/items")
+        assert resp.status_code == 200
+
+        # Simulate scenario when all scripts are flushed from the redis script cache
+        await app.state.redis.script_flush()
+        assert await _hash_exists() is False
+
+        # Request with unregistered script should succeed and re-register the script
+        resp = await app_client.get("/collections/naip/items")
+        assert resp.status_code == 200
+        assert await _hash_exists()


### PR DESCRIPTION
## Description

We've seen registered scripts be flushed from an active redis
connection. When that exception occurs, we now attempt to reregister the
scripts in a thread safe way, to avoid a sudden influx of
re-registrations.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Manually flushed scripts and new unit test that fails before fix was applied.

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [x] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)