### PR TITLE
Don't urlencode template urls used as JS literals

### DIFF
--- a/pctiler/pctiler/endpoints/templates/item_preview.html
+++ b/pctiler/pctiler/endpoints/templates/item_preview.html
@@ -17,7 +17,7 @@
     <script>
 
         $.ajax({
-            url: '{{ tileJson }}',
+            url: '{{ tileJson|safe }}',
             success: function (tileJson) {
                 var map = L.map('map', {
                     center: [tileJson.center[1], tileJson.center[0]],

--- a/pctiler/pctiler/endpoints/templates/mosaic_preview.html
+++ b/pctiler/pctiler/endpoints/templates/mosaic_preview.html
@@ -15,7 +15,7 @@
         <script src="https://code.jquery.com/jquery-3.6.0.min.js"></script>
         <script>
             $.ajax({
-                url: '{{ tileJson }}',
+                url: '{{ tileJson|safe }}',
                 success: function (tileJson) {
                     //show the jsonData in the page
                     console.log(tileJson)


### PR DESCRIPTION
## Description

The URLs injected into the preview jinja templates are by default
urlencoded (& -> &amp;). Previous versions of titiler tolerated these
malformed param separators, but the current version is more strict.


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

