### PR TITLE
Use correct package name for pcstac server

### DIFF
--- a/pcstac/Dockerfile
+++ b/pcstac/Dockerfile
@@ -14,4 +14,4 @@ RUN pip install -e ./pccommon -e ./pcstac[server]
 ENV APP_HOST=0.0.0.0
 ENV APP_PORT=81
 
-CMD uvicorn pctiler.main:app --host ${APP_HOST} --port ${APP_PORT} --log-level info
+CMD uvicorn pcstac.main:app --host ${APP_HOST} --port ${APP_PORT} --log-level info


### PR DESCRIPTION
## Description

Fixes a bug introduced in #73 which swapped the tiler package for the stac package for the uvicorn startup command

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)


## How Has This Been Tested?

Docker image was run locally outside of docker compose (which had the right command)

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [ ] Code is linted and styled (./scripts/format)