### PR TITLE
Upgrade fast-api to minimum version 0.75.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Move render config, queryables and mosaic info into Azure Storage Tables [#48](https://github.com/microsoft/planetary-computer-apis/pull/48)
 - Upgrades fastapi, stac-fastapi, and pgstac to 0.4.5 [#61](https://github.com/microsoft/planetary-computer-apis/pull/61)
 - pcstac moves to Python 3.9, uvicorn, and min/max database connections limited to 1 [#73](https://github.com/microsoft/planetary-computer-apis/pull/73)
+- Upgrades fastapi to 0.75.2 and fixes SwaggerUI vulnerability [82](https://github.com/microsoft/planetary-computer-apis/pull/82)
 
 ### Added
 

--- a/pccommon/setup.py
+++ b/pccommon/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 # Runtime requirements.
 inst_reqs = [
-    "fastapi==0.73.*",
+    "fastapi>=0.75.2",
     "opencensus-ext-azure==1.0.8",
     "opencensus-ext-logging==0.1.0",
     "orjson==3.5.2",


### PR DESCRIPTION
## Description

This release of fastapi is compatible with dependency versions in
stac-fastapi and titiler. It provides an upgrade to the SwaggerUI
dependency to >= 4.1.3, previous versions of which are vulnerable to
cross-site injection.

See:
- https://github.com/swagger-api/swagger-ui/security/advisories/GHSA-qrmm-w75w-3wpx
- https://github.com/tiangolo/fastapi/releases/tag/0.75.2

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

With an local deployment built with this version, go to the [docs ](http://localhost/stac/docs) page and in the JS console, type:

```js
> versions.swaggerUi.version
'4.10.3'
```
Further, you can add the `?url=` query string arg and set to another openapi.json file (e.g. data API) and confirm that the original docs are unchanged. On prod, the version is 3.52.5 and use of the `url` arg loads cross-site docs.

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [x] Changelog has been updated
- [x] Documentation has been updated
- [x] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)