### PR TITLE
Support interval legend types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added support for /queryables endpoint [#44](https://github.com/microsoft/planetary-computer-apis/pull/44)
 - Added `/mosaic/info` endpoint [#48](https://github.com/microsoft/planetary-computer-apis/pull/48)
 - Added caching and rate limiting to STAC API [#52](https://github.com/microsoft/planetary-computer-apis/pull/52)
+- Added endpoint for interval legend classmap [#83](https://github.com/microsoft/planetary-computer-apis/pull/83)
 
 ### Fixed
 

--- a/pctiler/pctiler/endpoints/legend.py
+++ b/pctiler/pctiler/endpoints/legend.py
@@ -13,6 +13,35 @@ from ..colormaps import custom_colormaps, registered_cmaps
 legend_router = APIRouter()
 
 
+@legend_router.get("/interval/{classmap_name}", response_class=JSONResponse)
+async def get_interval_legend(
+    classmap_name: str,
+    trim_start: int = 0,
+    trim_end: int = 0,
+) -> JSONResponse:
+    """Generate values and color swatches mapping for a given interval classmap.
+
+    Args:
+        trim_start (int, optional): Number of items to trim from the start of the cmap
+        trim_end (int, optional): Number of items to trim from the end of the cmap
+    """
+    classmap = custom_colormaps.get(classmap_name)
+
+    if classmap is None:
+        raise HTTPException(
+            status_code=404, detail=f"Classmap {classmap_name} not found"
+        )
+
+    if type(classmap) is not list:
+        raise HTTPException(
+            status_code=400, detail=f"Classmap {classmap_name} is not an interval type"
+        )
+
+    trimmed_map = classmap[trim_start : len(classmap) - trim_end]  # type: ignore
+
+    return JSONResponse(content=trimmed_map)
+
+
 @legend_router.get("/classmap/{classmap_name}", response_class=JSONResponse)
 async def get_classmap_legend(
     classmap_name: str,

--- a/pctiler/tests/endpoints/test_legends.py
+++ b/pctiler/tests/endpoints/test_legends.py
@@ -1,5 +1,39 @@
+import json
 import pytest
 from httpx import AsyncClient
+
+from pctiler.colormaps.lidarusgs import lidar_colormaps
+from pctiler.colormaps.lulc import lulc_colormaps
+
+
+@pytest.mark.asyncio
+async def test_get_invalid_interval(client: AsyncClient) -> None:
+    response = await client.get("/legend/interval/io-lulc")
+    assert response.status_code == 400
+
+
+@pytest.mark.asyncio
+async def test_get_interval(client: AsyncClient) -> None:
+    response = await client.get("/legend/interval/lidar-hag")
+    assert response.status_code == 200
+    interval = response.json()
+
+    # The interval has been serialized/deserialized which can change
+    # the sequence type, do the same to the original for comparison
+    lidar_json = json.loads(json.dumps(lidar_colormaps["lidar-hag"]))
+    assert interval == lidar_json
+
+
+@pytest.mark.asyncio
+async def test_trim_interval(client: AsyncClient) -> None:
+    # Trim the first and last entry from the classmap
+    response = await client.get("/legend/interval/lidar-hag?trim_start=1&trim_end=1")
+    interval = response.json()
+
+    lidar_hag = lidar_colormaps["lidar-hag"]
+    assert len(interval) == len(lidar_hag) - 2
+    assert interval[0] != lidar_hag[0]
+    assert interval[-1] != lidar_hag[-1]
 
 
 @pytest.mark.asyncio
@@ -7,7 +41,11 @@ async def test_get_classmap(client: AsyncClient) -> None:
     response = await client.get("/legend/classmap/io-lulc")
     assert response.status_code == 200
     classmap = response.json()
-    assert classmap["0"] == [0, 0, 0, 0]
+
+    # The classmap has been serialized/deserialized which can change
+    # the sequence type, do the same to the original for comparison
+    lulc_json = json.loads(json.dumps(lulc_colormaps["io-lulc"]))
+    assert classmap == lulc_json
 
 
 @pytest.mark.asyncio
@@ -17,7 +55,7 @@ async def test_trim_classmap(client: AsyncClient) -> None:
 
     keys = list(classmap.keys())
     key_start = keys[0]
-    key_end = keys[len(keys) - 1]
+    key_end = keys[-1]
 
     # Trim the first and last entry from the classmap
     response = await client.get("/legend/classmap/io-lulc?trim_start=1&trim_end=1")


### PR DESCRIPTION
## Description

- Return interval definitions from new `/legend/interval/<cmap-name>` endpoint.
- Refactor legend endpoint tests to be resilient to value changes of individual colormap definitinos

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## How Has This Been Tested?

New tests + local integration with Explorer

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [x] Changelog has been updated
- [x] Documentation has been updated
- [x] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)