### PR TITLE
Fix Sentinel 1 GRD rendering

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed bug in legend/colormap endpoint [#53](https://github.com/microsoft/planetary-computer-apis/pull/53)
+- Fixed tiler for Ground Control Point datasets, implemented for Sentinel 1 GRD [#90](https://github.com/microsoft/planetary-computer-apis/pull/90)
 
 
 ## [2022.1.3]

--- a/pctiler/pctiler/reader.py
+++ b/pctiler/pctiler/reader.py
@@ -4,7 +4,6 @@ from typing import Any, Dict, List, Optional, Tuple, Type
 
 import attr
 import morecantile
-from pctiler.config import get_settings
 import planetary_computer as pc
 from cogeo_mosaic.errors import NoAssetFoundError
 from fastapi import HTTPException
@@ -19,6 +18,7 @@ from titiler.pgstac.settings import CacheSettings
 
 from pccommon.cdn import BlobCDN
 from pccommon.config import get_render_config
+from pctiler.config import get_settings
 from pctiler.reader_cog import CustomCOGReader  # type:ignore
 
 logger = logging.getLogger(__name__)
@@ -46,6 +46,8 @@ class ItemSTACReader(PgSTACReader):
 @attr.s
 class MosaicSTACReader(pgstac_mosaic.CustomSTACReader):
     """Custom version of titiler.pgstac.mosaic.CustomSTACReader)."""
+
+    reader: Type[BaseReader] = attr.ib(default=CustomCOGReader)
 
     def _get_asset_url(self, asset: str) -> str:
         """Validate asset names and return asset's url.

--- a/pctiler/pctiler/reader_cog.py
+++ b/pctiler/pctiler/reader_cog.py
@@ -168,7 +168,7 @@ class CustomCOGReader(COGReader):
     """
 
     # dataset is not a input option.
-    dataset: WarpedVRT = attr.ib(init=False)
+    dataset: Union[DatasetReader, DatasetWriter, WarpedVRT] = attr.ib(init=False)
 
     def __attrs_post_init__(self):
         """Define _kwargs, open dataset and get info."""


### PR DESCRIPTION
Sentinel 1 GRD uses GCPs and does not have a CRS defined. This breaks the standard COGReader.

This commit adds the changes that exist in titiler's  GCPCOGReader for Sentinel 1 GRD, and sets the MosaicSTACReader to use the CustomCOGReader.

## How Has This Been Tested?

Locally against the item and mosaic endpoints. Tested io-lulc to ensure it doesn't interfere with non-GRD formats. Further testing will be done on deployed tilers

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [x] Changelog has been updated
- [x] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)