### PR TITLE
Update alos-fnf-mask

### DIFF
--- a/pctiler/pctiler/colormaps/alos_palsar_mosaic.py
+++ b/pctiler/pctiler/colormaps/alos_palsar_mosaic.py
@@ -11,8 +11,10 @@ alos_palsar_mosaic_colormaps: Dict[str, ColorMapType] = {
         255: (168, 153, 135, 255),
     },
     "alos-fnf": {
-        1: (0, 100, 0, 255),  # forest
-        2: (255, 255, 153, 255),  # non-forest
-        3: (0, 0, 255, 255),  # water
+        0: (0, 0, 0, 255),  # nodata
+        1: (0, 178, 0, 255),  # forest (> 90% canopy cover)
+        2: (131, 239, 98, 255),  # forest (10-90% canopy coer)
+        3: (255, 255, 153, 255),  # no-forest
+        4: (0, 0, 255, 255),  # water
     },
 }


### PR DESCRIPTION
Version 2 of the FNF assets include a new category (splitting "forest"
into two classes, depending on the canopy cover).

<img width="502" alt="image" src="https://user-images.githubusercontent.com/1312546/168609780-52612e80-e79b-40b3-a774-5bf626677382.png">
