### PR TITLE
switch to hypercorn to reduce memory leak

### DIFF
--- a/pcstac/Dockerfile
+++ b/pcstac/Dockerfile
@@ -13,5 +13,4 @@ RUN pip install -e ./pccommon -e ./pcstac[server]
 
 ENV APP_HOST=0.0.0.0
 ENV APP_PORT=81
-
-CMD uvicorn pcstac.main:app --host ${APP_HOST} --port ${APP_PORT} --log-level info
+CMD hypercorn pcstac.main:app --bind ${APP_HOST}:${APP_PORT} --log-level info

--- a/pcstac/setup.py
+++ b/pcstac/setup.py
@@ -29,7 +29,7 @@ extra_reqs = {
     ],
     # server deps
     "server": [
-        "uvicorn[standard]>=0.12.0,<0.16.0",
+        "hypercorn>=0.13,<0.14",
     ],
 }
 

--- a/pcstac/setup.py
+++ b/pcstac/setup.py
@@ -29,6 +29,7 @@ extra_reqs = {
     ],
     # server deps
     "server": [
+        "uvicorn[standard]>=0.12.0,<0.16.0",
         "hypercorn>=0.13,<0.14",
     ],
 }

--- a/pctiler/Dockerfile
+++ b/pctiler/Dockerfile
@@ -41,4 +41,4 @@ ENV MOSAIC_CONCURRENCY 1
 
 ENV APP_HOST=0.0.0.0
 ENV APP_PORT=80
-CMD uvicorn pctiler.main:app --host ${APP_HOST} --port ${APP_PORT} --log-level info
+CMD hypercorn pctiler.main:app --bind ${APP_HOST}:${APP_PORT} --log-level info

--- a/pctiler/setup.py
+++ b/pctiler/setup.py
@@ -36,6 +36,7 @@ extra_reqs = {
     ],
     # server deps
     "server": [
+        "uvicorn[standard]>=0.12.0,<0.16.0",
         "hypercorn>=0.13,<0.14",
     ],
 }

--- a/pctiler/setup.py
+++ b/pctiler/setup.py
@@ -36,7 +36,7 @@ extra_reqs = {
     ],
     # server deps
     "server": [
-        "uvicorn[standard]>=0.12.0,<0.16.0",
+        "hypercorn>=0.13,<0.14",
     ],
 }
 


### PR DESCRIPTION
This PR change the ASGI web server for the STAC and Raster API to use [Hypercorn](https://pgjones.gitlab.io/hypercorn/index.html) instead of Uvicorn. 

In https://github.com/tiangolo/fastapi/issues/1624 people mention that it resolved their issue. I've run a small tiler locally (simple titiler app) and confirmed that the memory growth was way more stable when using Hypercorn 
