### PR TITLE
Include hostname in redis cache key

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       - ./pcstac:/opt/src/pcstac
     depends_on:
       - database
+      - azurite
+      - redis
     command: >
       bash -c "pypgstac pgready && uvicorn pcstac.main:app --host 0.0.0.0 --port 8081 --reload --proxy-headers"
   tiler:
@@ -39,11 +41,13 @@ services:
       context: ./nginx
       dockerfile: Dockerfile
     links:
-      - stac
-      - tiler
+      - database
+      - azurite
+      - redis
     depends_on:
-      - tiler
-      - stac
+      - database
+      - azurite
+      - redis
     volumes:
       - ./nginx/etc/nginx:/etc/nginx
     ports:

--- a/pcstac/setup.py
+++ b/pcstac/setup.py
@@ -17,12 +17,12 @@ inst_reqs = [
 extra_reqs = {
     "test": [
         "pytest",
-        "pytest-asyncio",
+        "pytest-asyncio==0.18.*",
+        "httpx==0.19.0",
     ],
     "dev": [
         "black==22.3.0",
         "flake8==3.8.4",
-        "httpx==0.19.0",
         "isort==5.9.2",
         "mypy==0.800",
         "openapi-spec-validator==0.3.0",

--- a/pctiler/Dockerfile.dev
+++ b/pctiler/Dockerfile.dev
@@ -1,5 +1,3 @@
 FROM pc-apis-tiler
 
-COPY requirements-dev.txt /opt/src/requirements-dev.txt
-
-RUN pip install -r /opt/src/requirements-dev.txt
+RUN pip install -e ./pccommon -e ./pctiler[dev,test]

--- a/pctiler/setup.py
+++ b/pctiler/setup.py
@@ -27,12 +27,15 @@ inst_reqs = [
 extra_reqs = {
     "test": [
         "pytest",
-        "pytest-asyncio",
-        "httpx",
+        "pytest-asyncio==0.18.*",
+        "httpx==0.19.0",
     ],
     "dev": [
-        "pytest",
-        "pytest-asyncio",
+        "black==22.3.0",
+        "flake8==3.8.4",
+        "isort==5.9.2",
+        "mypy==0.800",
+        "openapi-spec-validator==0.3.0",
     ],
     # server deps
     "server": [

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+asyncio_mode = auto

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,8 +1,0 @@
-black==22.3.0
-flake8==3.8.4
-httpx==0.19.0
-isort==5.9.2
-mypy==0.800
-openapi-spec-validator==0.3.0
-pytest==6.2.5
-pytest-asyncio==0.15.1


### PR DESCRIPTION
## Description
As reported in https://github.com/microsoft/PlanetaryComputer/issues/65, items from planetarycomputer.microsoft.com endpoints were being returned with links to planetarycomputer-staging.microsoft.com. This was due to two things: the traffic from both hosts being routed to the same stack, which happens after a release due to our blue/green deployment workflow, and the redis caching mechanism not differentiating between traffic from staging and production. Requests from staging were being cached with a general key for that endpoint response, and that cached value was being returned for production requests.

This change includes the hostname in the redis cache keys to avoid this. All cached results will now be scoped to the hostname of the request.

In addition, this PR irons out some inconsistency with the installation of development dependencies. In one case, we were installing dev dependencies through setup.py, in the other, through requirements-dev.txt. This eliminates requirements-dev.txt and consolidates to the setup.py method. It also pins some dependency versions, and fixes some warnings output due to an upgrade in pytest_asyncio.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [ ] Changelog has been updated
- [x] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)