### PR TITLE
Fix issue with incorrect dev chart version

### DIFF
--- a/.github/workflows/publish-charts-dev.yml
+++ b/.github/workflows/publish-charts-dev.yml
@@ -15,12 +15,14 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0 # Required due to the way Git works, without it this action won't be able to find any or the correct tags
 
       - name: 'Get Previous tag'
         id: previoustag
         uses: "WyriHaximus/github-action-get-previous-tag@v1"
         with:
-          fallback: 2021.3.0
+          fallback: 2022.2.0
 
       - name: 'Get next minor version'
         id: semvers


### PR DESCRIPTION
Fix tag fetching in the `publish-charts-dev.yaml` workflow by fitting to this example: https://github.com/marketplace/actions/get-latest-tag#example

Seems that `fetch-depth: 0` is required on checkout.