### PR TITLE
Fix the setup command line in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This project uses a variation on [scripts to rule them all](https://github.com/g
 To set up a local environment, use
 
 ```
-> ./scripts/update
+> ./scripts/setup
 ```
 
 This will build containers, apply database migrations, and load the development data.


### PR DESCRIPTION
## Description

Fix the setup command line in README

## Type of change

- [x] This change is a documentation update

Without this change following the documentation results in an empty database.