### PR TITLE
Update gh-pages for function packages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,15 @@
+# Jekyll
+Gemfile
+Gemfile.lock
+_site/
+
+# Config
+.venv
+*.env
+
+# main branch folders
+deployment/
+pccommon/
+pcfuncs/
+pcstac/
+pctiler/

--- a/_config.yaml
+++ b/_config.yaml
@@ -1,5 +1,5 @@
-title: Planetary Computer APIs Helm charts for Kubernetes
-description: This site stores Helm chart tarballs for the Planteary Computer APIs
+title: Planetary Computer APIs Function packages and Helm charts
+description: This site stores Function package zip files and Helm chart tarballs for the Planteary Computer APIs
 theme: minima
 url: "https://microsoft.github.io/planetary-computer-apis"
 repo_name: planetary-computer-apis

--- a/_data/func-index.yaml
+++ b/_data/func-index.yaml
@@ -1,0 +1,1 @@
+../func-index.yaml

--- a/func-index.yaml
+++ b/func-index.yaml
@@ -1,0 +1,3 @@
+generated: "2022-09-13T19:19:42.320072+00:00"
+name: Planetary Computer Functions Package Index
+packages:

--- a/func-packages/README.md
+++ b/func-packages/README.md
@@ -1,0 +1,4 @@
+# func-packages
+
+This directory contains the deployable source code packages for the pcfuncs API
+project. File metadata is indexed in `../func-index.yaml`.

--- a/index.md
+++ b/index.md
@@ -2,9 +2,11 @@
 layout: default
 ---
 
-## Getting Started
+# Getting Started
 
 {{ site.description }}
+
+## Helm repository
 
 You can add this repository to your local helm configuration as follows :
 
@@ -42,4 +44,18 @@ $ helm install --version {{ latest_chart.version }} myrelease {{ site.repo_name 
 | [{{ chart.name }}-{{ chart.version }}]({{ chart.urls[0] }}) |{% for dep in chart.dependencies %} {{ dep.version | capitalize }} |{% endfor %} {{ chart.appVersion }} | {{ chart.created | date_to_long_string }} |
 {% endfor -%}
 
+{% endfor %}
+
+## Function packages
+
+### {{ site.data.func-index.name }}
+
+{{ site.data.func-index.description }}
+
+Last updated: {{ site.data.func-index.generated | date_to_long_string }}
+
+| Package | Version | Date |
+|---------|---------|------|
+{% for package in site.data.func-index.packages | sort: 'created' | reverse -%}
+| [{{ package.name }}]({{ package.url }}) | {{ package.version }} | {{ package.created | date_to_long_string }} |
 {% endfor %}


### PR DESCRIPTION
## Description

Updates GitHub pages template with index information from function packages published to `gh-pages` branch.

Related #117 

## How Has This Been Tested?

Local Jekyll builds.