### PR TITLE
Set the routePrefix for pcfunc to api/f/v1

### DIFF
--- a/nginx/etc/nginx/conf.d/default.conf
+++ b/nginx/etc/nginx/conf.d/default.conf
@@ -43,15 +43,15 @@ server {
     }
 
     # Funcs
-    location /f {
+    location /f/ {
         proxy_set_header Host $http_host;
         proxy_set_header X-Forwarded-For $remote_addr;
         proxy_buffers 8 8k;
         proxy_buffer_size "16k";
         proxy_connect_timeout  120;
 
-        proxy_pass http://funcs-upstream;
-        proxy_redirect http://funcs-upstream/ /f;
+        # Pass requests for http://localhost:8080/f/{endpoint} to http://funcs:80/api/f/v1/{endpoint}
+        proxy_pass http://funcs-upstream/api/f/v1/;
 
         # Allow CORS at the nginx level because function runtime doesn't expose the settings
         # https://github.com/Azure/azure-functions-host/issues/5090
@@ -63,6 +63,5 @@ server {
             return 204;
         }
 
-        rewrite ^/f/?(.*)$ /$1 break;
     }
 }

--- a/pcfuncs/host.json
+++ b/pcfuncs/host.json
@@ -18,7 +18,7 @@
   },
   "extensions": {
     "http": {
-        "routePrefix": ""
+      "routePrefix": "api/f/v1"
     }
-}
+  }
 }


### PR DESCRIPTION
## Description

By proxying through nginx, the local URLs will stay the same and we'll be able to match on URL paths through Frontdoor in prod.

