### PR TITLE
Log request entity

### DIFF
--- a/pccommon/pccommon/constants.py
+++ b/pccommon/pccommon/constants.py
@@ -18,6 +18,11 @@ X_AZURE_CLIENTIP = "X-Azure-ClientIP"
 X_ORIGINAL_FORWARDED_FOR = "X-Original-Forwarded-For"
 X_FORWARDED_FOR = "X-Forwarded-For"
 
+X_REQUEST_ENTITY = "X-PC-Request-Entity"
+X_AZURE_REF = "X-Azure-Ref"
+
+QS_REQUEST_ENTITY = "request_entity"
+
 HTTP_429_TOO_MANY_REQUESTS = 429
 
 HTTP_PATH = COMMON_ATTRIBUTES["HTTP_PATH"]

--- a/pccommon/pccommon/logging.py
+++ b/pccommon/pccommon/logging.py
@@ -11,7 +11,14 @@ from fastapi import Request
 from opencensus.ext.azure.log_exporter import AzureLogHandler
 
 from pccommon.config import get_apis_config
-from pccommon.constants import HTTP_METHOD, HTTP_PATH, HTTP_URL
+from pccommon.constants import (
+    HTTP_METHOD,
+    HTTP_PATH,
+    HTTP_URL,
+    QS_REQUEST_ENTITY,
+    X_AZURE_REF,
+    X_REQUEST_ENTITY,
+)
 
 
 class ServiceName:
@@ -111,11 +118,21 @@ def request_to_path(request: Request) -> str:
     return parsed_url.path
 
 
+def get_request_entity(request: Request) -> str:
+    """Get the request entity from the given request. If not present as a
+    header, attempt to parse from the query string
+    """
+    return request.headers.get(X_REQUEST_ENTITY) or request.query_params.get(
+        QS_REQUEST_ENTITY
+    )
+
+
 def get_custom_dimensions(dimensions: dict, request: Request) -> dict:
     """Merge the base dimensions with the given dimensions."""
 
     base_dimensions = {
-        "ref_id": request.headers.get("X-Azure-Ref"),
+        "ref_id": request.headers.get(X_AZURE_REF),
+        "request_entity": get_request_entity(request),
         "service": request.app.state.service_name,
         HTTP_URL: str(request.url),
         HTTP_METHOD: str(request.method),

--- a/pccommon/pccommon/logging.py
+++ b/pccommon/pccommon/logging.py
@@ -4,7 +4,7 @@ across all services
 
 import logging
 import sys
-from typing import Optional, Tuple, cast
+from typing import Optional, Tuple, Union, cast
 from urllib.parse import urlparse
 
 from fastapi import Request
@@ -118,7 +118,7 @@ def request_to_path(request: Request) -> str:
     return parsed_url.path
 
 
-def get_request_entity(request: Request) -> str:
+def get_request_entity(request: Request) -> Union[str, None]:
     """Get the request entity from the given request. If not present as a
     header, attempt to parse from the query string
     """

--- a/pcstac/pcstac/main.py
+++ b/pcstac/pcstac/main.py
@@ -79,7 +79,7 @@ app.state.service_name = ServiceName.STAC
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins="*",
+    allow_origins=["*"],
     allow_methods=["GET", "POST"],
     allow_headers=["*"],
 )

--- a/pcstac/setup.py
+++ b/pcstac/setup.py
@@ -12,6 +12,8 @@ inst_reqs = [
     # Required due to some imports related to pypgstac CLI usage in startup script
     "pypgstac[psycopg]==0.6.6",
     "pystac==1.*",
+    # TODO: remove after https://github.com/stac-utils/stac-fastapi/pull/466
+    "pygeoif==0.7",
 ]
 
 extra_reqs = {

--- a/pctiler/pctiler/main.py
+++ b/pctiler/pctiler/main.py
@@ -93,8 +93,8 @@ if settings.debug:
 
 app.add_middleware(
     CORSMiddleware,
-    allow_origins="*",
-    allow_credentials=True,
+    allow_origins=["*"],
+    allow_credentials=False,
     allow_methods=["GET", "POST"],
     allow_headers=["*"],
 )


### PR DESCRIPTION
## Description

Fix CORS setting and log an optional header `x-pc-request-entity` that can identify a known-entity request origin application.

