### PR TITLE
Remove sleep call in pcfunc tile fetching

### DIFF
--- a/pc-funcs.dev.env
+++ b/pc-funcs.dev.env
@@ -3,10 +3,10 @@ WEBSITE_HOSTNAME=funcs:8083
 
 ANIMATION_OUTPUT_STORAGE_URL="http://azurite:10000/devstoreaccount1/output/animations"
 ANIMATION_OUTPUT_ACCOUNT_KEY="Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
-ANIMATION_API_ROOT_URL="https://planetarycomputer.microsoft.com/api/data/v1"
+ANIMATION_API_ROOT_URL="https://planetarycomputer-staging.microsoft.com/api/data/v1"
 ANIMATION_TILE_REQUEST_CONCURRENCY=2
 
 IMAGE_OUTPUT_STORAGE_URL="http://azurite:10000/devstoreaccount1/output/images"
 IMAGE_OUTPUT_ACCOUNT_KEY="Eby8vdM02xNOcqFlqUwJPLlmEtlCDXJ1OUzFT50uSRZ6IFsuFq2UVErCz4I6tq/K1SZFPTOtr/KBHBeksoGMGw=="
-IMAGE_API_ROOT_URL="https://planetarycomputer.microsoft.com/api/data/v1"
+IMAGE_API_ROOT_URL="https://planetarycomputer-staging.microsoft.com/api/data/v1"
 IMAGE_TILE_REQUEST_CONCURRENCY=2

--- a/pcfuncs/funclib/tiles.py
+++ b/pcfuncs/funclib/tiles.py
@@ -162,11 +162,6 @@ class PILTileSet(TileSet[PILRaster]):
             async with aiohttp.ClientSession() as session:
                 async with self._async_limit:
                     async with session.get(url) as resp:
-                        # Download the image tile, block if exceeding concurrency limits
-                        if self._async_limit.locked():
-                            logger.info("Concurrency limit reached, waiting...")
-                            await asyncio.sleep(1)
-
                         if resp.status == 200:
                             return io.BytesIO(await resp.read())
                         else:


### PR DESCRIPTION
## Description

The sleep call did have an effect of spreading out requests over time, but in an arbitrary and non-efficient manner. The semaphore context block effectively blocks on a counter-based lock.

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [x] Changelog has been updated
- [x] Documentation has been updated
- [x] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)