### PR TITLE
Fix func backoff error

### DIFF
--- a/pcfuncs/funclib/tiles.py
+++ b/pcfuncs/funclib/tiles.py
@@ -175,8 +175,8 @@ class PILTileSet(TileSet[PILRaster]):
                 is_throttle=lambda e: isinstance(e, TilerError),
                 strategy=BackoffStrategy(waits=[0.2, 0.5, 0.75, 1, 2]),
             )
-        except TilerError as e:
-            logger.warning(f"Tile request: {e.resp.status} {url}")
+        except Exception:
+            logger.warning(f"Tile request failed with backoff: {url}")
             img_bytes = Image.new("RGB", (self.tile_size, self.tile_size), "gray")
             empty = io.BytesIO()
             img_bytes.save(empty, format="png")

--- a/pcstac/setup.py
+++ b/pcstac/setup.py
@@ -10,7 +10,7 @@ inst_reqs = [
     "stac-fastapi.types @ git+https://github.com/stac-utils/stac-fastapi/@162a1a2c324b4c2bfe3451f7ae19d7840a0e0452#egg=stac-fastapi.types&subdirectory=stac_fastapi/types",
     "pccommon",
     # Required due to some imports related to pypgstac CLI usage in startup script
-    "pypgstac[psycopg]==0.6.6",
+    "pypgstac[psycopg]==0.6.9",
     "pystac==1.*",
     # TODO: remove after https://github.com/stac-utils/stac-fastapi/pull/466
     "pygeoif==0.7",


### PR DESCRIPTION
## Description

Rather than looking for TileError, assume any error emitted from the backoff strategy should result in a blank tile. Typically, this will actually be a BackoffError with an inner error of TileError.

