### PR TITLE
Add continuous colormap for noaa mrms qpe

### DIFF
--- a/pctiler/pctiler/colormaps/__init__.py
+++ b/pctiler/pctiler/colormaps/__init__.py
@@ -15,6 +15,7 @@ from .modis import modis_colormaps
 from .mtbs import mtbs_colormaps
 from .noaa_c_cap import noaa_c_cap_colormaps
 from .noaa_mrms_qpe import noaa_mrms_qpe_colormaps
+from .qpe import qpe_colormaps
 from .viirs import viirs_colormaps
 
 ################################################################################
@@ -33,6 +34,7 @@ custom_colormaps: Dict[str, ColorMapType] = {
     **noaa_c_cap_colormaps,
     **noaa_mrms_qpe_colormaps,
     **alos_palsar_mosaic_colormaps,
+    **qpe_colormaps,
     **viirs_colormaps,
 }
 

--- a/pctiler/pctiler/colormaps/qpe.py
+++ b/pctiler/pctiler/colormaps/qpe.py
@@ -1,0 +1,55 @@
+from typing import Dict, cast
+
+import matplotlib
+import numpy as np
+from rio_tiler.types import ColorMapType, ColorTuple
+
+
+def make_qpe_colormap() -> ColorMapType:
+    qpe = matplotlib.colors.LinearSegmentedColormap.from_list(
+        "qpe",
+        [
+            (0.000, "#00000000"),
+            (0.003, "#1863b7"),
+            (0.010, "#1863b7"),
+            (0.011, "#30817e"),
+            (0.025, "#30817e"),
+            (0.026, "#419944"),
+            (0.050, "#419944"),
+            (0.051, "#5dac12"),
+            (0.075, "#5dac12"),
+            (0.076, "#94ba15"),
+            (0.100, "#94ba15"),
+            (0.101, "#c6c61e"),
+            (0.150, "#c6c61e"),
+            (0.151, "#f1cb24"),
+            (0.200, "#f1cb24"),
+            (0.201, "#fbb621"),
+            (0.250, "#fbb621"),
+            (0.251, "#f8981b"),
+            (0.300, "#f8981b"),
+            (0.301, "#f47916"),
+            (0.400, "#f47916"),
+            (0.401, "#f15a1e"),
+            (0.500, "#f15a1e"),
+            (0.501, "#fa605d"),
+            (0.600, "#fa605d"),
+            (0.601, "#ff79aa"),
+            (0.800, "#ff79aa"),
+            (0.801, "#fe92fb"),
+            (1.000, "#fe92fb"),
+        ],
+        256,
+    )
+    ramp = np.linspace(0, 1, 256)
+    cmap_vals = qpe(ramp)[:, :]
+    cmap_uint8 = (cmap_vals * 255).astype("uint8")
+    colormap = {
+        idx: cast(ColorTuple, tuple(value)) for idx, value in enumerate(cmap_uint8)
+    }
+    return colormap
+
+
+qpe_colormaps: Dict[str, ColorMapType] = {
+    "qpe": make_qpe_colormap(),
+}


### PR DESCRIPTION
## Description

Adds a replacement _continuous_ colormap for the NOAA MRMS QPE dataset. The current QPE colormap is of _interval_ type. The continuous colormap enables a simple colorbar that provides an immediate indication that the colormap is nonlinear, takes up less space, and is generally more attractive (IMO). The new colorbar will also be annotated with corrected precipitation depths.

The existing `noaa-mrms-qpe` colormap is retained so that we don't break production when this PR is merged. The new colormap is named `qpe`. Once merged, we will tweak the render configs for the three QPE collections in Test and Staging (use the new colormap, set appropriate `rescale` limits, add legend labels), and copy to production when that looks good. We can then delete the existing `noaa-mrms-qpe` colormap with a new PR.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

### tiler preview endpoint
I imported the noaa-mrms-qpe-1h-pass1 Collection and a few Items into the local pgstac database and used the tiler preview endpoint to render an image with the new colormap:

![titiler-endpoint-qpe](https://user-images.githubusercontent.com/7013017/199857607-01ac86ce-b50f-4dd8-862c-0b95c463acc9.png)

### legend endpoint

The legend endpoint also renders the colorbar correctly:

![legend-endpoint-qpe](https://user-images.githubusercontent.com/7013017/199857688-749971f2-ff58-4b0c-ae34-326c57f8cdda.png)

### PC Test

I inserted an approximation (URL string limited to 200 of the 256 elements of the colormap) of the new colormap into the render configuration for the noaa-mrms-qpe-1h-pass1 Collection in PC Test. It looks as expected:

![pctest-qpe](https://user-images.githubusercontent.com/7013017/199857959-5f619258-a9df-4929-89a5-be47c6f50a13.png)

The colorbar does not render, but I believe that is because PC Test can't see the new colormap (and can't build one off of the URL string in the render config renderOptions section).

The new colormap _may_ have corrected the nodata problem for the CARIB region, i.e., it is not necessary to append `&nodata=0` to the mosaic render options in the render configuration. 

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)