### PR TITLE
Update fastapi, stacfastapi version

### DIFF
--- a/pccommon/setup.py
+++ b/pccommon/setup.py
@@ -4,12 +4,8 @@ from setuptools import find_packages, setup
 
 # Runtime requirements.
 inst_reqs = [
-    # --->
-    # TODO: restore fastapi release install after starlette dep upgraded to >= 0.21.0
-    # "fastapi>=0.75.2",
-    "fastapi @ git+https://github.com/mmcfarland/fastapi/@982e7caf086bffeace8554da6d69e5f3082f14a3#egg=fastapi",
-    "starlette>=0.21.0,<0.22.0",
-    # <---
+    "fastapi>=0.87",
+    "starlette>=0.22.0,<0.23.0",
     "opencensus-ext-azure==1.0.8",
     "opencensus-ext-logging==0.1.0",
     "orjson==3.5.2",

--- a/pcfuncs/requirements-deploy.txt
+++ b/pcfuncs/requirements-deploy.txt
@@ -10,7 +10,7 @@ requests==2.28.1
 aiohttp==3.8.1
 dateutils==0.6.12
 mercantile==1.2.1
-pillow==9.3.0
+pillow==9.3.1
 pyproj==3.3.1
 pydantic>=1.9,<2.0.0
 rasterio==1.3.*

--- a/pcstac/setup.py
+++ b/pcstac/setup.py
@@ -4,16 +4,14 @@ from setuptools import find_packages, setup
 
 # Runtime requirements.
 inst_reqs = [
-    "stac-fastapi.api @ git+https://github.com/stac-utils/stac-fastapi/@162a1a2c324b4c2bfe3451f7ae19d7840a0e0452#egg=stac-fastapi.api&subdirectory=stac_fastapi/api",
-    "stac-fastapi.extensions @ git+https://github.com/stac-utils/stac-fastapi/@162a1a2c324b4c2bfe3451f7ae19d7840a0e0452#egg=stac-fastapi.extensions&subdirectory=stac_fastapi/extensions",
-    "stac-fastapi.pgstac @ git+https://github.com/stac-utils/stac-fastapi/@162a1a2c324b4c2bfe3451f7ae19d7840a0e0452#egg=stac-fastapi.pgstac&subdirectory=stac_fastapi/pgstac",
-    "stac-fastapi.types @ git+https://github.com/stac-utils/stac-fastapi/@162a1a2c324b4c2bfe3451f7ae19d7840a0e0452#egg=stac-fastapi.types&subdirectory=stac_fastapi/types",
+    "stac-fastapi.api @ git+https://github.com/stac-utils/stac-fastapi/@25879afe94296eb82b94b523bfa2871b686e035a#egg=stac-fastapi.api&subdirectory=stac_fastapi/api",
+    "stac-fastapi.extensions @ git+https://github.com/stac-utils/stac-fastapi/@25879afe94296eb82b94b523bfa2871b686e035a#egg=stac-fastapi.extensions&subdirectory=stac_fastapi/extensions",
+    "stac-fastapi.pgstac @ git+https://github.com/stac-utils/stac-fastapi/@25879afe94296eb82b94b523bfa2871b686e035a#egg=stac-fastapi.pgstac&subdirectory=stac_fastapi/pgstac",
+    "stac-fastapi.types @ git+https://github.com/stac-utils/stac-fastapi/@25879afe94296eb82b94b523bfa2871b686e035a#egg=stac-fastapi.types&subdirectory=stac_fastapi/types",
     "pccommon",
     # Required due to some imports related to pypgstac CLI usage in startup script
     "pypgstac[psycopg]==0.6.9",
     "pystac==1.*",
-    # TODO: remove after https://github.com/stac-utils/stac-fastapi/pull/466
-    "pygeoif==0.7",
 ]
 
 extra_reqs = {


### PR DESCRIPTION
## Description

Updates to released versions of fastapi now that a needed starlette dep has been upgraded. stac-fastapi is updated but still not using a release due to some advanced work in the pgstac backend that we don't want to incorporate yet (queryables).

