### PR TITLE
sketch for raw raster support in pcfuncs

### DIFF
--- a/pcfuncs/requirements.txt
+++ b/pcfuncs/requirements.txt
@@ -14,6 +14,7 @@ pillow==9.3.0
 pyproj==3.3.1
 pydantic>=1.9,<2.0.0
 rasterio==1.3.*
+rio-tiler==3.1.*  # same as titiler 0.7.0
 
 # Deployment needs to copy the local code into
 # the app code directory, so requires a separate

--- a/pcfuncs/tests/funclib/test_raster.py
+++ b/pcfuncs/tests/funclib/test_raster.py
@@ -1,6 +1,8 @@
 from pathlib import Path
 
-from funclib.raster import Bbox, PILRaster, RasterExtent
+import rasterio
+from funclib.models import RIOImage
+from funclib.raster import Bbox, GDALRaster, PILRaster, RasterExtent
 from PIL import Image
 
 HERE = Path(__file__).parent
@@ -35,3 +37,22 @@ def test_raster_extent_map_to_grid() -> None:
 
     assert x == 5
     assert y == 5
+
+
+def test_rio_crop() -> None:
+    with rasterio.open(DATA_FILES / "s2.png") as src:
+        img = RIOImage.from_rio(src)
+
+    raster = GDALRaster(
+        extent=RasterExtent(
+            bbox=Bbox(0, 0, 10, 10),
+            cols=img.size[0],
+            rows=img.size[1],
+        ),
+        image=img,
+    )
+
+    cropped = raster.crop(Bbox(0, 0, 5, 5))
+
+    assert abs(cropped.extent.cols - (img.size[0] / 2)) < 1
+    assert abs(cropped.extent.rows - (img.size[1] / 2)) < 1


### PR DESCRIPTION
This PR adds support for `raw` raster support in pcfuncs to allow direct access to the raster tiles values (instead of using PNG/JPEG representation of the data). This means that tiles should be required as `tiff` (png/jpeg/webp format will still be possible). 

## To Do
- [ ] write more tests 