### PR TITLE
Kv firewall

### DIFF
--- a/deployment/bin/azlogin
+++ b/deployment/bin/azlogin
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+set -e
+
+if [[ "${CI}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Login to Azure CLI
+"
+}
+
+while [[ "$#" -gt 0 ]]; do case $1 in
+    *)
+        usage "Unknown parameter passed: $1"
+        shift
+        shift
+        ;;
+    esac done
+
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+
+    az login --service-principal \
+        --username ${AZURE_CLIENT_ID} \
+        --password ${AZURE_CLIENT_SECRET} \
+        --tenant ${AZURE_TENANT_ID}
+
+fi

--- a/deployment/bin/azlogin
+++ b/deployment/bin/azlogin
@@ -25,8 +25,8 @@ while [[ "$#" -gt 0 ]]; do case $1 in
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
     az login --service-principal \
-        --username ${AZURE_CLIENT_ID} \
-        --password ${AZURE_CLIENT_SECRET} \
-        --tenant ${AZURE_TENANT_ID}
+        --username ${ARM_CLIENT_ID} \
+        --password ${ARM_CLIENT_SECRET} \
+        --tenant ${ARM_TENANT_ID}
 
 fi

--- a/deployment/bin/deploy
+++ b/deployment/bin/deploy
@@ -80,6 +80,13 @@ echo "IMAGE_TAG: ${IMAGE_TAG}"
 
 if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
+    #########################
+    # Add IP to KV firewall #
+    #########################
+
+    bin/azlogin
+    bin/kv_add_ip
+
     #####################
     # Deploy Terraform  #
     #####################
@@ -102,6 +109,12 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
     gather_tf_output
 
     popd
+
+    ##############################
+    # Remove IP from KV firewall #
+    ##############################
+
+    bin/kv_rmv_ip
 
     ############################
     # Render Helm chart values #

--- a/deployment/bin/kv_add_ip
+++ b/deployment/bin/kv_add_ip
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+if [[ "${CI}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Add runner public IP to Key Vault firewall allow list
+"
+}
+
+while [[ "$#" -gt 0 ]]; do case $1 in
+    *)
+        usage "Unknown parameter passed: $1"
+        shift
+        shift
+        ;;
+    esac done
+
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+
+    runnerIpAddress=$(curl http://ipinfo.io/json | jq -r ".ip")
+
+    az keyvault network-rule add -g ${KEY_VAULT_RESOURCE_GROUP_NAME}  -n ${KEY_VAULT_NAME} --ip-address $runnerIpAddress
+
+fi

--- a/deployment/bin/kv_rmv_ip
+++ b/deployment/bin/kv_rmv_ip
@@ -1,0 +1,31 @@
+#!/bin/bash
+
+set -e
+
+if [[ "${CI}" ]]; then
+    set -x
+fi
+
+function usage() {
+    echo -n \
+        "Usage: $(basename "$0")
+Remove runner public IP from Key Vault firewall allow list
+"
+}
+
+while [[ "$#" -gt 0 ]]; do case $1 in
+    *)
+        usage "Unknown parameter passed: $1"
+        shift
+        shift
+        ;;
+    esac done
+
+
+if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
+
+    runnerIpAddress=$(curl http://ipinfo.io/json | jq -r ".ip")
+
+    az keyvault network-rule remove -g ${KEY_VAULT_RESOURCE_GROUP_NAME}  -n ${KEY_VAULT_NAME} --ip-address $runnerIpAddress
+
+fi

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -23,6 +23,10 @@ services:
       - GITHUB_TOKEN
       - GITHUB_REPOSITORY
       - GITHUB_ACTOR
+
+      # Used to open KV firewall for accessing tf.secrets
+      - KEY_VAULT_NAME=pc-test-deploy-secrets
+      - KEY_VAULT_RESOURCE_GROUP_NAME=pc-test-manual-resources
     working_dir: /opt/src/deployment
     volumes:
       - ../deployment:/opt/src/deployment


### PR DESCRIPTION
## Description

During [deploy](https://github.com/microsoft/planetary-computer-apis/blob/eb5c48826e09662a827cc539ebf34d21a3784571/deployment/bin/deploy#L83-L105), terraform requires access to a KV to retrieve [secrets](https://github.com/microsoft/planetary-computer-apis/blob/eb5c48826e09662a827cc539ebf34d21a3784571/deployment/terraform/resources/keyvault.tf#L6-L14). Said KV has to update its firewall rule to only **"Allow public access from specific virtual networks and IP addresses"**.

The current changes are meant to authenticate as an Azure Service Principal and include the current runner public IP into the KV's firewall allow list.
Once the task is done, the IP is removed.

The KV name and it's RG name are set as env variables over the [docker-compose.yml](https://github.com/microsoft/planetary-computer-apis/blob/e8ad357c8a6f91b4d4c04db0c5ed04ab6a7ac260/deployment/docker-compose.yml#L27-L29).

#### Fixes # Security Scanning Services - Compliance: Key Vault must have public access disabled.

## Type of change

Please delete options that are not relevant.

- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

TBD

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [ ] Code is linted and styled (./scripts/format)