### PR TITLE
Upgrade AKS to supported version

### DIFF
--- a/deployment/terraform/resources/aks.tf
+++ b/deployment/terraform/resources/aks.tf
@@ -16,6 +16,7 @@ resource "azurerm_kubernetes_cluster" "pc" {
     vm_size        = "Standard_DS2_v2"
     node_count     = var.aks_node_count
     vnet_subnet_id = azurerm_subnet.node_subnet.id
+    orchestrator_version = var.k8s_version
   }
 
   identity {

--- a/deployment/terraform/staging/main.tf
+++ b/deployment/terraform/staging/main.tf
@@ -4,7 +4,7 @@ module "resources" {
   environment = "staging"
   region = "West Europe"
 
-  k8s_version = "1.22.6"
+  k8s_version = "1.25.5"
 
   cluster_cert_issuer = "letsencrypt"
   cluster_cert_server = "https://acme-v02.api.letsencrypt.org/directory"

--- a/deployment/terraform/staging/main.tf
+++ b/deployment/terraform/staging/main.tf
@@ -2,25 +2,25 @@ module "resources" {
   source = "../resources"
 
   environment = "staging"
-  region = "West Europe"
+  region      = "West Europe"
 
   k8s_version = "1.25.5"
 
   cluster_cert_issuer = "letsencrypt"
   cluster_cert_server = "https://acme-v02.api.letsencrypt.org/directory"
 
-  aks_node_count = 2
-  stac_replica_count = 2
+  aks_node_count      = 2
+  stac_replica_count  = 2
   tiler_replica_count = 2
 
   # Funcs
-  output_storage_account_name = "pcfilestest"
-  output_container_name = "output"
-  funcs_data_api_url = "https://planetarycomputer.microsoft.com/api/data/v1"
+  output_storage_account_name    = "pcfilestest"
+  output_container_name          = "output"
+  funcs_data_api_url             = "https://planetarycomputer.microsoft.com/api/data/v1"
   funcs_tile_request_concurrency = 10
 
   animation_output_storage_url = "https://pcfilestest.blob.core.windows.net/output/animations"
-  image_output_storage_url = "https://pcfilestest.blob.core.windows.net/output/images"
+  image_output_storage_url     = "https://pcfilestest.blob.core.windows.net/output/images"
 
 }
 
@@ -34,6 +34,6 @@ terraform {
 }
 
 output "resources" {
-  value = module.resources
+  value     = module.resources
   sensitive = true
 }


### PR DESCRIPTION
The staging-test AKS version deployed by CI fell out of support.