### PR TITLE
Add io-bii colormap

### DIFF
--- a/pctiler/pctiler/colormaps/__init__.py
+++ b/pctiler/pctiler/colormaps/__init__.py
@@ -7,8 +7,8 @@ from rio_tiler.types import ColorMapType
 from titiler.core.dependencies import ColorMapParams
 
 from .alos_palsar_mosaic import alos_palsar_mosaic_colormaps
-from .io_bii import io_bii_colormaps
 from .chloris import chloris_colormaps
+from .io_bii import io_bii_colormaps
 from .jrc import jrc_colormaps
 from .lidarusgs import lidar_colormaps
 from .lulc import lulc_colormaps

--- a/pctiler/pctiler/colormaps/__init__.py
+++ b/pctiler/pctiler/colormaps/__init__.py
@@ -7,6 +7,7 @@ from rio_tiler.types import ColorMapType
 from titiler.core.dependencies import ColorMapParams
 
 from .alos_palsar_mosaic import alos_palsar_mosaic_colormaps
+from .io_bii import io_bii_colormaps
 from .chloris import chloris_colormaps
 from .jrc import jrc_colormaps
 from .lidarusgs import lidar_colormaps
@@ -24,6 +25,7 @@ from .viirs import viirs_colormaps
 ################################################################################
 registered_cmaps = cmap
 custom_colormaps: Dict[str, ColorMapType] = {
+    **io_bii_colormaps,
     **jrc_colormaps,
     **lulc_colormaps,
     **modis_colormaps,

--- a/pctiler/pctiler/colormaps/io_bii.py
+++ b/pctiler/pctiler/colormaps/io_bii.py
@@ -1,0 +1,32 @@
+from typing import Dict, cast
+
+import matplotlib
+import numpy as np
+from rio_tiler.types import ColorMapType, ColorTuple
+
+
+def make_io_bii_colormap() -> ColorMapType:
+    io_bii = matplotlib.colors.LinearSegmentedColormap.from_list(
+        "io_bii",
+        [
+            (0.0, "#72736c"),
+            (0.2, "#ccd3c5"),
+            (0.4, "#cceaa2"),
+            (0.6, "#69be72"),
+            (0.8, "#309d53"),
+            (1.0, "#006a37"),
+        ],
+        256,
+    )
+    ramp = np.linspace(0, 1, 256)
+    cmap_vals = io_bii(ramp)[:, :]
+    cmap_uint8 = (cmap_vals * 255).astype("uint8")
+    colormap = {
+        idx: cast(ColorTuple, tuple(value)) for idx, value in enumerate(cmap_uint8)
+    }
+    return colormap
+
+
+io_bii_colormaps: Dict[str, ColorMapType] = {
+    "io-bii": make_io_bii_colormap(),
+}


### PR DESCRIPTION
## Description

Adds a continuous colormap for the Impact Observatory Biodiversity Intactness Index (io-bii) dataset modeled after the [UN Biodiversity Intactness Index](https://map.unbiodiversitylab.org/earth?basemap=grayscale&coordinates=20,0,2&layers=biodiversity-intactness-index_100) colormap. The colormap is intended for use with the io-bii data transformed as 0.97*(data**3.84) and rescaled to [0, 1]. This results in a logarithmic colormap that focuses on intactness index values in the 0.6 to 0.95 range to better distinguish land areas that are close to the [critical 0.9 index](https://www.science.org/doi/10.1126/science.aaf2201) value.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

### Item tile preview endpoint

I imported the io-bii Collection and a few Items into a local pgstac database and used the tile preview endpoint to render an image with the proposed colormap:

![preview](https://user-images.githubusercontent.com/7013017/224322013-116c1032-c61b-46f3-a738-ed0ea9366169.png)

### legend colormap endpoint

The legend endpoint also renders the colorbar correctly:

![legend](https://user-images.githubusercontent.com/7013017/224322175-aea0580b-d3a7-40b3-a64e-15acacae593a.png)

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)