### PR TITLE
Run uvicorn as docker root user

### DIFF
--- a/pctiler/Dockerfile
+++ b/pctiler/Dockerfile
@@ -46,4 +46,8 @@ ENV MOSAIC_CONCURRENCY 1
 
 ENV APP_HOST=0.0.0.0
 ENV APP_PORT=80
+
+# Run uvicorn as root. The build context user is $MAMBA_USER which doesn't have
+# permission to bind to port 80.
+USER root
 CMD uvicorn pctiler.main:app --host ${APP_HOST} --port ${APP_PORT} --log-level info


### PR DESCRIPTION
## Description

The tiler base image was switched to micro-mamba in order to source a particular build of rasterio, however the image user did not have permission to bind to port 80 to run uvicorn. Switching the uvicorn execution to root restores previous behavior.
