### PR TITLE
SA min TLS version

### DIFF
--- a/deployment/terraform/resources/storage_account.tf
+++ b/deployment/terraform/resources/storage_account.tf
@@ -4,6 +4,7 @@ resource "azurerm_storage_account" "pc" {
   location                 = azurerm_resource_group.pc.location
   account_tier             = "Standard"
   account_replication_type = "LRS"
+  min_tls_version          = "TLS1_2"
 }
 
 # Tables


### PR DESCRIPTION
Enforce Storage Account minimum TLS version to meet compliance standard: `Use approved version of TLS for Azure Storage: Current minimum TLS version [1.0] is less than required version [1.2].`