### PR TITLE
update titiler.pgstac

### DIFF
--- a/pctiler/environment.yaml
+++ b/pctiler/environment.yaml
@@ -18,4 +18,4 @@ dependencies:
 
       -  # titiler-pgstac
       - "psycopg[binary,pool]"
-      - "titiler.pgstac==0.2.2"
+      - "titiler.pgstac==0.2.4"


### PR DESCRIPTION
update titiler.pgstac to 0.2.4 to get the retry mechanism 

ref https://github.com/stac-utils/titiler-pgstac/pull/90 

We may want to use the `TITILER_PGSTAC_API_RETRY` and `TITILER_PGSTAC_API_DELAY` environment to configure the retry settings (by default it's 3 retry and 0 second delay)