### PR TITLE
Update to Azure Linux

### DIFF
--- a/deployment/terraform/resources/aks.tf
+++ b/deployment/terraform/resources/aks.tf
@@ -5,17 +5,11 @@ resource "azurerm_kubernetes_cluster" "pc" {
   dns_prefix          = "${local.prefix}-cluster"
   kubernetes_version  = var.k8s_version
 
-  addon_profile {
-    kube_dashboard {
-      enabled = false
-    }
-  }
-
   default_node_pool {
-    name           = "agentpool"
-    vm_size        = "Standard_DS2_v2"
-    node_count     = var.aks_node_count
-    vnet_subnet_id = azurerm_subnet.node_subnet.id
+    name                 = "agentpool"
+    vm_size              = "Standard_DS2_v2"
+    node_count           = var.aks_node_count
+    vnet_subnet_id       = azurerm_subnet.node_subnet.id
     orchestrator_version = var.k8s_version
   }
 
@@ -23,19 +17,10 @@ resource "azurerm_kubernetes_cluster" "pc" {
     type = "SystemAssigned"
   }
 
-  role_based_access_control {
-    enabled = true
-    azure_active_directory {
-      managed = true
-      azure_rbac_enabled = true
-    }
-
+  azure_active_directory_role_based_access_control {
+    managed            = true
+    azure_rbac_enabled = true
   }
-  # TODO(azurerm 3.x)
-  # azure_active_directory_role_based_access_control {
-  #   managed = true
-  #   azure_rbac_enabled = true
-  # }
 
   tags = {
     Environment = var.environment

--- a/deployment/terraform/resources/aks.tf
+++ b/deployment/terraform/resources/aks.tf
@@ -12,9 +12,6 @@ resource "azurerm_kubernetes_cluster" "pc" {
     node_count           = var.aks_node_count
     vnet_subnet_id       = azurerm_subnet.node_subnet.id
     orchestrator_version = var.k8s_version
-
-    # remove this after deploying
-    temporary_name_for_rotation = "tmpdefault"
   }
 
   identity {

--- a/deployment/terraform/resources/aks.tf
+++ b/deployment/terraform/resources/aks.tf
@@ -7,10 +7,14 @@ resource "azurerm_kubernetes_cluster" "pc" {
 
   default_node_pool {
     name                 = "agentpool"
+    os_sku               = "AzureLinux"
     vm_size              = "Standard_DS2_v2"
     node_count           = var.aks_node_count
     vnet_subnet_id       = azurerm_subnet.node_subnet.id
     orchestrator_version = var.k8s_version
+
+    # remove this after deploying
+    temporary_name_for_rotation = "tmpdefault"
   }
 
   identity {

--- a/deployment/terraform/resources/ip.tf
+++ b/deployment/terraform/resources/ip.tf
@@ -5,6 +5,7 @@ resource "azurerm_public_ip" "pc" {
   location            = azurerm_resource_group.pc.location
   allocation_method   = "Static"
   sku                 = "Standard"
+  zones               = ["1", "2", "3"]
 
   tags = {
     environment = var.environment

--- a/deployment/terraform/resources/providers.tf
+++ b/deployment/terraform/resources/providers.tf
@@ -8,7 +8,7 @@ terraform {
   required_providers {
     azurerm = {
       source  = "hashicorp/azurerm"
-      version = "2.74.0"
+      version = "3.77.0"
     }
   }
 }

--- a/deployment/terraform/resources/storage_account.tf
+++ b/deployment/terraform/resources/storage_account.tf
@@ -1,10 +1,11 @@
 resource "azurerm_storage_account" "pc" {
-  name                     = "${local.nodash_prefix}sa"
-  resource_group_name      = azurerm_resource_group.pc.name
-  location                 = azurerm_resource_group.pc.location
-  account_tier             = "Standard"
-  account_replication_type = "LRS"
-  min_tls_version          = "TLS1_2"
+  name                            = "${local.nodash_prefix}sa"
+  resource_group_name             = azurerm_resource_group.pc.name
+  location                        = azurerm_resource_group.pc.location
+  account_tier                    = "Standard"
+  account_replication_type        = "LRS"
+  min_tls_version                 = "TLS1_2"
+  allow_nested_items_to_be_public = false
 }
 
 # Tables

--- a/deployment/terraform/staging/main.tf
+++ b/deployment/terraform/staging/main.tf
@@ -4,7 +4,7 @@ module "resources" {
   environment = "staging"
   region      = "West Europe"
 
-  k8s_version = "1.25.5"
+  k8s_version = "1.25.6"
 
   cluster_cert_issuer = "letsencrypt"
   cluster_cert_server = "https://acme-v02.api.letsencrypt.org/directory"


### PR DESCRIPTION
## Description

This updates the terraform deployment to use Azure Linux for the OS SKU type on the container hosts.

One of the properties needed to roll out the change required updating the azurerm provider version. Those change are in 8f75b8e8aa50638ac1bfdf2b37db4edbd588f8a5.