### PR TITLE
Minimal updates to deployment Dockerfile

### DIFF
--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 RUN apt-get update --fix-missing
 RUN apt-get install -y wget unzip curl gnupg \
@@ -23,10 +23,9 @@ RUN mv terraform /usr/local/bin
 
 # Install kubectl
 
-RUN curl -s https://packages.cloud.google.com/apt/doc/apt-key.gpg | apt-key add -
-RUN echo "deb https://apt.kubernetes.io/ kubernetes-xenial main" | tee -a /etc/apt/sources.list.d/kubernetes.list
-RUN apt-get update
-RUN apt-get install -y kubectl
+RUN curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+RUN install -o root -g root -m 0755 kubectl /usr/local/bin/kubectl
+
 
 # Install Helm
 


### PR DESCRIPTION
## Description

Upgrade to a supported LTS release of Ubuntu and change the install source of kubectl for compatibility. Previously, the deploy image would not build, resulting in CI/CD pipeline failures.
