### PR TITLE
Package publish permissions and ICU lib for dotnet functools

### DIFF
--- a/.github/workflows/publish-charts-dev.yml
+++ b/.github/workflows/publish-charts-dev.yml
@@ -12,6 +12,8 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    permissions:
+        contents: write
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish-charts.yml
+++ b/.github/workflows/publish-charts.yml
@@ -12,6 +12,8 @@ defaults:
 jobs:
   build:
     runs-on: ubuntu-20.04
+    permissions:
+        contents: write
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/publish-func-package-dev.yml
+++ b/.github/workflows/publish-func-package-dev.yml
@@ -12,6 +12,8 @@ defaults:
 jobs:
   publish:
     runs-on: ubuntu-20.04
+    permissions:
+        contents: write
 
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/publish-func-package.yml
+++ b/.github/workflows/publish-func-package.yml
@@ -12,6 +12,8 @@ defaults:
 jobs:
   publish:
     runs-on: ubuntu-20.04
+    permissions:
+        contents: write
 
     steps:
       - uses: actions/checkout@v3

--- a/deployment/Dockerfile
+++ b/deployment/Dockerfile
@@ -1,11 +1,12 @@
 FROM ubuntu:20.04
 
 RUN apt-get update --fix-missing
-RUN apt-get install -y wget unzip curl gnupg \
+RUN DEBIAN_FRONTEND=noninteractive apt-get install -y wget unzip curl gnupg \
     apt-transport-https \
     python3-pip \
     jq \
-    git
+    git \
+    libicu66
 
 # Install Azure Function Tools
 


### PR DESCRIPTION
## Description

Sets a the `write` permission for the chart/func package publish jobs, which need to write to the gh-pages branch of the repo. This permission was previously set at the repo level, and may not be adjustable. Also adds a libicu dependency required for func-tools on ubuntu 20.04. This package has an interactive step, so much be installed in `noninteractive` mode.