### PR TITLE
Fix Duplicate Prefix Issue in OpenAPI Schema

### DIFF
--- a/pccommon/pccommon/openapi.py
+++ b/pccommon/pccommon/openapi.py
@@ -46,7 +46,10 @@ def fix_openapi_output(openapi_dict: Dict) -> None:
 
 def set_root_path(root_path: str, schema: Dict[str, Any]) -> Dict[str, Any]:
     def _append_root_path(k: str) -> str:
-        return f"{root_path}{k}"
+        # Only prepend root_path if it's not already included in the server's URL
+        if all(root_path not in server.get("url", "") for server in schema.get("servers", [])):
+            return f"{root_path}{k}"
+        return k
 
     return {
         **{k: v for k, v in schema.items() if k != "paths"},

--- a/pccommon/pccommon/openapi.py
+++ b/pccommon/pccommon/openapi.py
@@ -47,7 +47,10 @@ def fix_openapi_output(openapi_dict: Dict) -> None:
 def set_root_path(root_path: str, schema: Dict[str, Any]) -> Dict[str, Any]:
     def _append_root_path(k: str) -> str:
         # Only prepend root_path if it's not already included in the server's URL
-        if all(root_path not in server.get("url", "") for server in schema.get("servers", [])):
+        if all(
+            root_path not in server.get("url", "")
+            for server in schema.get("servers", [])
+        ):
             return f"{root_path}{k}"
         return k
 


### PR DESCRIPTION
## Description

This PR addresses an issue where API routes were getting duplicated prefixes in our OpenAPI documentation. Previously, we appended a root path to each path in the paths dictionary. However, since our schema already specifies a base URL in the servers section (e.g., {'url': '/stac'}), this led to the unintended duplication of the base path in the final URLs (stac/stac) 

Fixes # (issue)
https://github.com/microsoft/PlanetaryComputer/issues/332

## Type of change

Please delete options that are not relevant.
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration
Deployed local server and test /stac/docs
![image](https://github.com/microsoft/planetary-computer-apis/assets/100631414/76d1686d-a6f2-4fee-90f6-3739febc15e1)

## Checklist:

Please delete options that are not relevant.
- [x] Unit tests pass locally (./scripts/test)
- [ ] Code is linted and styled (./scripts/format)