### PR TITLE
Change the CI helm chart to reference pcccr

### DIFF
--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -6,8 +6,8 @@ services:
       context: ..
       dockerfile: deployment/Dockerfile
     environment:
-      - ACR_STAC_REPO=${ACR_STAC_REPO:-mcr.microsoft.com/planetary-computer-apis/stac}
-      - ACR_TILER_REPO=${ACR_TILER_REPO:-mcr.microsoft.com/planetary-computer-apis/tiler}
+      - ACR_STAC_REPO=${ACR_STAC_REPO:-pcccr.azurecr.io/private/planetary-computer-apis/stac}
+      - ACR_TILER_REPO=${ACR_TILER_REPO:-pcccr.azurecr.io/private/planetary-computer-apis/tiler}
       - IMAGE_TAG
       - GIT_COMMIT
 

--- a/deployment/terraform/staging/main.tf
+++ b/deployment/terraform/staging/main.tf
@@ -9,6 +9,8 @@ module "resources" {
   cluster_cert_issuer = "letsencrypt"
   cluster_cert_server = "https://acme-v02.api.letsencrypt.org/directory"
 
+  pc_test_resources_acr = "pcccr"
+
   aks_node_count      = 2
   stac_replica_count  = 2
   tiler_replica_count = 2


### PR DESCRIPTION
## Description

Change the CI helm chart to reference the new image name https://pcccr.azurecr.io/private/planetary-computer-apis/stac and tiler

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

Please delete options that are not relevant.

- [ ] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [ ] Code is linted and styled (./scripts/format)