### PR TITLE
Publish tagged builds to pccomponents

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -33,14 +33,16 @@ jobs:
           case "${GITHUB_REF}" in
             *tags*)
               echo "tag=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT
+              echo "ACR=pccomponents" >> $GITHUB_OUTPUT
               ;;
             *)
               echo "tag=latest" >> $GITHUB_OUTPUT
+              echo "ACR=pccomponentstest" >> $GITHUB_OUTPUT
               ;;
           esac
 
       - name: Publish images
-        run: ./scripts/cipublish --acr pccomponentstest --tag ${{steps.get_image_tag.outputs.tag}}
+        run: ./scripts/cipublish --acr ${{steps.get_image_tag.outputs.ACR}} --tag ${{steps.get_image_tag.outputs.tag}}
 
     outputs:
       image_tag: ${{ steps.get_image_tag.outputs.tag }}

--- a/scripts/cipublish
+++ b/scripts/cipublish
@@ -120,17 +120,8 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
         install_oras
     fi
 
-    # only _tagged_ releases will be synced from pcccr to MAR
-    case $IMAGE_TAG in
-        *latest*)
-            image_prefix="private"
-            ;;
-        *)
-            image_prefix="public"
-            ;;
-    esac
     # Publish images
-    publish_image "pc-apis-stac" "$image_prefix/planetary-computer-apis/stac"
-    publish_image "pc-apis-tiler" "$image_prefix/planetary-computer-apis/tiler"
+    publish_image "pc-apis-stac" "planetary-computer-apis/stac"
+    publish_image "pc-apis-tiler" "planetary-computer-apis/tiler"
 
 fi


### PR DESCRIPTION
## Description

We need a way to selectively publish tagged builds to `pccomponents` so that the production Planetary Computer cluster references those tagged images. Previously they were coming from MCR but we have stopped publishing them to MCR. 

Removal of the `private`/`public` prefix is just to make this repository match others in `pccomponents`.