### PR TITLE
Upgrade to linux function app and use identity based storage connection for function app

### DIFF
--- a/deployment/terraform/resources/output.tf
+++ b/deployment/terraform/resources/output.tf
@@ -137,5 +137,5 @@ output "redis_port" {
 # Functions
 
 output "function_app_name" {
-  value = azurerm_function_app.pcfuncs.name
+  value = azurerm_linux_function_app.pcfuncs.name
 }


### PR DESCRIPTION
## Description

This is a follow-up to the [PR](https://github.com/microsoft/planetary-computer-apis/pull/215) which adds a timer-triggered function to function app. Azure Functions use storage accounts to store the state and checkpoints for timer-triggered functions to ensure that they run on schedule and can recover from failures. 

We've disabled account key access to storage account for security reasons, we only temporarily enable it during access, so in order for function app to run successfully, it needs to use System-assigned managed identity to access the storage account.

I did not catch this during testing in previous PR because several invocations of functions were triggered during deployment where  account key access was enabled.

I upgraded `azurerm_function_app` to `azurerm_linux_function_app` for two reasons:
1. In [Terraform doc](https://registry.terraform.io/providers/hashicorp/azurerm/latest/docs/resources/function_app), `azurerm_function_app` has been deprecated in provider 3.0 and will be removed in 4.0
2. `storage_uses_managed_identity` is only available in `azurerm_linux_function_app` and it allows the function app to use managed identity instead of access key

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

After local/pipeline deploy, check if the function can be triggered manually and periodically.

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [ ] Code is linted and styled (./scripts/format)