### PR TITLE
Disallow public traffic to storage accounts

### DIFF
--- a/deployment/bin/kv_add_ip
+++ b/deployment/bin/kv_add_ip
@@ -28,9 +28,19 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
     cidr=$(get_cidr_range)
 
+    echo "Adding IP $cidr to Key Vault firewall allow list..."
     az keyvault network-rule add \
         -g ${KEY_VAULT_RESOURCE_GROUP_NAME}  \
         -n ${KEY_VAULT_NAME} \
+        --ip-address $cidr \
+        --subscription ${ARM_SUBSCRIPTION_ID} \
+        --output none
+
+    # Also add the IP to the terraform state storage account
+    echo "Adding IP $cidr to Storage firewall allow list..."
+    az storage account network-rule add \
+        -g ${TFSTATE_SA_RG} \
+        -n ${TFSTATE_SA_NAME} \
         --ip-address $cidr \
         --subscription ${ARM_SUBSCRIPTION_ID} \
         --output none

--- a/deployment/bin/kv_rmv_ip
+++ b/deployment/bin/kv_rmv_ip
@@ -28,9 +28,18 @@ if [ "${BASH_SOURCE[0]}" = "${0}" ]; then
 
     cidr=$(get_cidr_range)
 
+    echo "Removing IP $cidr from Key Vault firewall allow list..."
     az keyvault network-rule remove \
         -g ${KEY_VAULT_RESOURCE_GROUP_NAME}  \
         -n ${KEY_VAULT_NAME} \
+        --ip-address $cidr \
+        --subscription ${ARM_SUBSCRIPTION_ID} \
+        --output none
+
+    echo "Removing IP $cidr from Storage firewall allow list..."
+    az storage account network-rule remove \
+        -g ${TFSTATE_SA_RG} \
+        -n ${TFSTATE_SA_NAME} \
         --ip-address $cidr \
         --subscription ${ARM_SUBSCRIPTION_ID} \
         --output none

--- a/deployment/bin/lib
+++ b/deployment/bin/lib
@@ -142,6 +142,7 @@ function disable_shared_access_keys() {
             --name ${SAK_STORAGE_ACCOUNT} \
             --resource-group ${SAK_RESOURCE_GROUP} \
             --allow-shared-key-access false \
+            --subscription ${ARM_SUBSCRIPTION_ID} \
             --output none
 
         if [ $? -ne 0 ]; then
@@ -168,6 +169,7 @@ function enable_shared_access_keys() {
             --name ${SAK_STORAGE_ACCOUNT} \
             --resource-group ${SAK_RESOURCE_GROUP} \
             --allow-shared-key-access true \
+            --subscription ${ARM_SUBSCRIPTION_ID} \
             --output none
     done
 }

--- a/deployment/docker-compose.yml
+++ b/deployment/docker-compose.yml
@@ -32,6 +32,10 @@ services:
       # Used to open KV firewall for accessing tf.secrets
       - KEY_VAULT_NAME=pc-test-deploy-secrets
       - KEY_VAULT_RESOURCE_GROUP_NAME=pc-test-manual-resources
+
+      # Used to open firewall to tfstate SA
+      - TFSTATE_SA_RG=pc-test-manual-resources
+      - TFSTATE_SA_NAME=pctesttfstate
     working_dir: /opt/src/deployment
     volumes:
       - ../deployment:/opt/src/deployment

--- a/deployment/terraform/resources/storage_account.tf
+++ b/deployment/terraform/resources/storage_account.tf
@@ -7,6 +7,11 @@ resource "azurerm_storage_account" "pc" {
   min_tls_version                 = "TLS1_2"
   allow_nested_items_to_be_public = false
 
+  network_rules {
+    default_action             = "Deny"
+    virtual_network_subnet_ids = [azurerm_subnet.node_subnet.id, ]
+  }
+
   # Disabling shared access keys breaks terraform's ability to do subsequent
   # resource fetching during terraform plan. As a result, this property is
   # ignored and managed outside of this apply session, via the deploy script.


### PR DESCRIPTION
## Description

This PR sets the storage account in the test deployment to disallow traffic that is not in the node subnet of the vnet.
This PR adds logic to the deploy script to enable access to the terraform state SA that is denies public internet traffic.

TODO:
- [ ] Update to allow function app access to the SA after #226 is merged.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?



## Checklist:

Please delete options that are not relevant.

- [ ] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [ ] Code is linted and styled (./scripts/format)