### PR TITLE
Upgrade stac urllib3

### DIFF
--- a/pccommon/requirements.txt
+++ b/pccommon/requirements.txt
@@ -151,7 +151,7 @@ typing-extensions==4.10.0
     #   azure-storage-blob
     #   pydantic
     #   starlette
-urllib3==2.2.1
+urllib3==2.2.2
     # via
     #   pccommon (pccommon/setup.py)
     #   requests

--- a/pctiler/requirements-dev.txt
+++ b/pctiler/requirements-dev.txt
@@ -18,11 +18,11 @@ attrs==23.2.0
     #   morecantile
     #   rasterio
     #   rio-tiler
-boto3==1.34.123
+boto3==1.34.136
     # via
     #   pctiler (pctiler/setup.py)
     #   rio-tiler
-botocore==1.34.123
+botocore==1.34.136
     # via
     #   boto3
     #   pctiler (pctiler/setup.py)

--- a/pctiler/requirements-server.txt
+++ b/pctiler/requirements-server.txt
@@ -21,11 +21,11 @@ attrs==23.2.0
     #   morecantile
     #   rasterio
     #   rio-tiler
-boto3==1.34.123
+boto3==1.34.136
     # via
     #   pctiler (pctiler/setup.py)
     #   rio-tiler
-botocore==1.34.123
+botocore==1.34.136
     # via
     #   boto3
     #   pctiler (pctiler/setup.py)
@@ -251,7 +251,7 @@ typing-extensions==4.10.0
     #   psycopg-pool
     #   pydantic
     #   starlette
-urllib3==1.26.18
+urllib3==1.26.19
     # via
     #   botocore
     #   requests

--- a/pctiler/setup.py
+++ b/pctiler/setup.py
@@ -13,18 +13,16 @@ inst_reqs: List[str] = [
     "titiler.core==0.10.2",
     "titiler.mosaic==0.10.2",
     "pillow==10.3.0",
-    "boto3==1.34.123",
-    "botocore==1.34.123",
+    "boto3==1.34.136",
+    "botocore==1.34.136",
     "pydantic==1.10.14",
     "idna>=3.7.0",
     "requests==2.32.2",
     # titiler-pgstac
     "psycopg[binary,pool]",
     "titiler.pgstac==0.2.4",
-
     # colormap dependencies
     "matplotlib==3.9.0",
-
     "orjson==3.10.4",
     "importlib_resources>=1.1.0;python_version<'3.9'",
 ]


### PR DESCRIPTION
## Description

Security patches for urlib3 for pcstac. `boto3` doesn't appear to support recent versions, and we have a requirement from rio-tiler.