### PR TITLE
Add subnet of pct-sas kubernetes cluster to pct-api storage account

### DIFF
--- a/deployment/terraform/resources/storage_account.tf
+++ b/deployment/terraform/resources/storage_account.tf
@@ -9,7 +9,7 @@ resource "azurerm_storage_account" "pc" {
 
   network_rules {
     default_action             = "Deny"
-    virtual_network_subnet_ids = [azurerm_subnet.node_subnet.id, azurerm_subnet.function_subnet.id]
+    virtual_network_subnet_ids = [azurerm_subnet.node_subnet.id, azurerm_subnet.function_subnet.id, data.azurerm_subnet.sas_node_subnet.id]
   }
 
   # Disabling shared access keys breaks terraform's ability to do subsequent

--- a/deployment/terraform/resources/variables.tf
+++ b/deployment/terraform/resources/variables.tf
@@ -144,6 +144,17 @@ variable "func_storage_account_url" {
   type = string
 }
 
+variable "sas_node_subnet_name" {
+  type = string
+}
+
+variable "sas_node_subnet_virtual_network_name" {
+  type = string
+}
+
+variable "sas_node_subnet_resource_group_name" {
+  type = string
+}
 # -----------------
 # Local variables
 

--- a/deployment/terraform/resources/vnet.tf
+++ b/deployment/terraform/resources/vnet.tf
@@ -26,6 +26,12 @@ resource "azurerm_subnet" "cache_subnet" {
   service_endpoints    = []
 }
 
+data "azurerm_subnet" "sas_node_subnet" {
+  name                 = var.sas_node_subnet_name
+  virtual_network_name = var.sas_node_subnet_virtual_network_name
+  resource_group_name  = var.sas_node_subnet_resource_group_name
+}
+
 resource "azurerm_subnet" "function_subnet" {
   name                 = "${local.prefix}-functions-subnet"
   virtual_network_name = azurerm_virtual_network.pc.name

--- a/deployment/terraform/staging/main.tf
+++ b/deployment/terraform/staging/main.tf
@@ -26,6 +26,10 @@ module "resources" {
   prod_log_analytics_workspace_id   = "78d48390-b6bb-49a9-b7fd-a86f6522e9c4"
   func_storage_account_url          = "https://pctapisstagingsa.table.core.windows.net/"
   banned_ip_table                   = "blobstoragebannedip"
+
+  sas_node_subnet_name                 = "pct-sas-westeurope-staging-node-subnet"
+  sas_node_subnet_virtual_network_name = "pct-sas-westeurope-staging-network"
+  sas_node_subnet_resource_group_name  = "pct-sas-westeurope-staging_rg"
 }
 
 terraform {


### PR DESCRIPTION
## Description

`pct-sas` kubernetes cluster needs to access the ip ban table in `pct-api` storage account and therefore subnet configuration are added.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Subnet has been added successfully as I checked in portal UI.

## Checklist:

Please delete options that are not relevant.

- [ ] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [ ] Code is linted and styled (./scripts/format)