### PR TITLE
Upgrade FastAPI to 0.99 and Starlette for OpenAPI 3.1.x Swagger UI Render Support

### DIFF
--- a/pccommon/requirements.txt
+++ b/pccommon/requirements.txt
@@ -42,7 +42,7 @@ cryptography==42.0.5
     #   pyjwt
 exceptiongroup==1.2.0
     # via anyio
-fastapi==0.92.0
+fastapi==0.99.0
     # via pccommon (pccommon/setup.py)
 google-api-core==2.18.0
     # via opencensus
@@ -137,7 +137,7 @@ sniffio==1.3.1
     # via anyio
 soupsieve==2.5
     # via beautifulsoup4
-starlette==0.25.0
+starlette==0.27.0
     # via
     #   fastapi
     #   pccommon (pccommon/setup.py)
@@ -149,6 +149,7 @@ typing-extensions==4.10.0
     #   azure-core
     #   azure-data-tables
     #   azure-storage-blob
+    #   fastapi
     #   pydantic
     #   starlette
 urllib3==2.2.2

--- a/pccommon/requirements.txt
+++ b/pccommon/requirements.txt
@@ -42,7 +42,7 @@ cryptography==42.0.5
     #   pyjwt
 exceptiongroup==1.2.0
     # via anyio
-fastapi==0.90.1
+fastapi==0.92.0
     # via pccommon (pccommon/setup.py)
 google-api-core==2.18.0
     # via opencensus
@@ -137,7 +137,7 @@ sniffio==1.3.1
     # via anyio
 soupsieve==2.5
     # via beautifulsoup4
-starlette==0.22.0
+starlette==0.25.0
     # via
     #   fastapi
     #   pccommon (pccommon/setup.py)

--- a/pccommon/setup.py
+++ b/pccommon/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 # Runtime requirements.
 inst_reqs = [
-    "fastapi==0.92.0",
+    "fastapi==0.99.0",
     "starlette>=0.25.0,<0.28.0",
     "opencensus-ext-azure==1.1.13",
     "opencensus-ext-logging==0.1.1",

--- a/pccommon/setup.py
+++ b/pccommon/setup.py
@@ -4,8 +4,8 @@ from setuptools import find_packages, setup
 
 # Runtime requirements.
 inst_reqs = [
-    "fastapi==0.90.1",
-    "starlette>=0.22.0,<0.23.0",
+    "fastapi==0.92.0",
+    "starlette>=0.25.0,<0.28.0",
     "opencensus-ext-azure==1.1.13",
     "opencensus-ext-logging==0.1.1",
     "orjson>=3.10.4",


### PR DESCRIPTION
## Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)
This pull request addresses a bug where the [SAS](https://planetarycomputer.microsoft.com/docs/reference/sas) & [STAC](https://planetarycomputer.microsoft.com/docs/reference/stac) Catalog API Reference pages aren't rendering. The fix involves upgrading FastAPI to version 0.99 and updating Starlette to ensure compatibility with OpenAPI 3.1.x and proper rendering by the Swagger UI.

- [x] Bug fix (non-breaking change which fixes an issue)

## How Has This Been Tested?

Passes tests locally


## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [x] Changelog has been updated
- [x] Documentation has been updated
- [x] Unit tests pass locally (./scripts/test)
- [x] Code is linted and styled (./scripts/format)