### PR TITLE
Add comments to clarify usage of DefaultAzureCredential in credential…

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,5 @@
 [flake8]
-max-line-length = 88
+max-line-length = 120
 extend-ignore = E203, W503
 exclude =
     .git

--- a/pccommon/pccommon/credential.py
+++ b/pccommon/pccommon/credential.py
@@ -24,5 +24,5 @@ class PcDefaultAzureCredential:
     def get_credential(cls) -> DefaultAzureCredential:
         if cls._instance is None:
             with cls._lock:
-                cls._instance = DefaultAzureCredential()
+                cls._instance = DefaultAzureCredential() # CodeQL [SM05139] Automatically switches to managed identity in production
         return cls._instance

--- a/pccommon/pccommon/credential.py
+++ b/pccommon/pccommon/credential.py
@@ -24,5 +24,7 @@ class PcDefaultAzureCredential:
     def get_credential(cls) -> DefaultAzureCredential:
         if cls._instance is None:
             with cls._lock:
-                cls._instance = DefaultAzureCredential() # CodeQL [SM05139] Automatically switches to managed identity in production
+                cls._instance = (
+                    DefaultAzureCredential()  # CodeQL [SM05139] Automatically switches to managed identity in prod
+                )
         return cls._instance

--- a/pcfuncs/ipban/__init__.py
+++ b/pcfuncs/ipban/__init__.py
@@ -17,7 +17,9 @@ def main(mytimer: func.TimerRequest) -> None:
         datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
     )
     logger.info("Updating the ip ban list at %s", utc_timestamp)
-    credential: DefaultAzureCredential = DefaultAzureCredential() # CodeQL [SM05139] Used only as servicability module not deployed in production
+    credential: DefaultAzureCredential = (
+        DefaultAzureCredential()  # CodeQL [SM05139] Used only as servicability module not deployed in production
+    )
     with LogsQueryClient(credential) as logs_query_client:
         with TableServiceClient(
             endpoint=settings.storage_account_url, credential=credential

--- a/pcfuncs/ipban/__init__.py
+++ b/pcfuncs/ipban/__init__.py
@@ -17,7 +17,7 @@ def main(mytimer: func.TimerRequest) -> None:
         datetime.datetime.utcnow().replace(tzinfo=datetime.timezone.utc).isoformat()
     )
     logger.info("Updating the ip ban list at %s", utc_timestamp)
-    credential: DefaultAzureCredential = DefaultAzureCredential()
+    credential: DefaultAzureCredential = DefaultAzureCredential() # CodeQL [SM05139] Used only as servicability module not deployed in production
     with LogsQueryClient(credential) as logs_query_client:
         with TableServiceClient(
             endpoint=settings.storage_account_url, credential=credential


### PR DESCRIPTION
….py and __init__.py

## Description

Add comments to clarify usage of DefaultAzureCredential to make CodeQL warnings happy

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Local build verification.

## Checklist:

Please delete options that are not relevant.

- [x] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [ ] Code is linted and styled (./scripts/format)