### PR TITLE
Fix tag variable in Publish Image step

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -43,17 +43,18 @@ jobs:
 
       - name: Publish Image
         id: publish_image
-        run:
+        run: |
           case "${GITHUB_REF}" in
             *tags*)
-              echo "tag=${GITHUB_REF/refs\/tags\//}" >> $GITHUB_OUTPUT ;
-              ./scripts/cipublish --acr pccomponents --tag $tag
+              tag=${GITHUB_REF/refs\/tags\//}
+              echo "tag=${tag}" >> $GITHUB_OUTPUT
+              ./scripts/cipublish --acr pccomponents --tag ${tag}
               ;;
             *)
-              echo "Publishing to pccomponentstest as latest" ;
-              echo "tag=latest" >> $GITHUB_OUTPUT ;
-              ./scripts/cipublish --acr pccomponentstest --tag latest ;
-              echo "Also publishing to pccomponents ACR with unique tag" ;
+              echo "Publishing to pccomponentstest as latest"
+              echo "tag=latest" >> $GITHUB_OUTPUT
+              ./scripts/cipublish --acr pccomponentstest --tag latest
+              echo "Also publishing to pccomponents ACR with unique tag"
               ./scripts/cipublish --acr pccomponents --tag ${{ steps.most-recent-tag.outputs.tag }}.${{ github.run_number }}
               ;;
           esac


### PR DESCRIPTION
## Description

Fix tag variable initialisation in Publish Image step to properly extract and use tag name from git reference. 

Addresses: https://github.com/microsoft/planetary-computer-apis/actions/runs/19644058576/job/56348155639#annotation:9:17

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

Please delete options that are not relevant.

- [ ] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [ ] Code is linted and styled (./scripts/format)