### PR TITLE
update titiler-pgstac to 1.3.1 for pgstac 9 support

### DIFF
--- a/pctiler/pyproject.toml
+++ b/pctiler/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
     "requests>=2.32.4",
     "titiler.core==0.18.3",
     "titiler.mosaic==0.18.3",
-    "titiler.pgstac==1.3.0",
+    "titiler.pgstac==1.3.1",
 ]
 
 [project.optional-dependencies]

--- a/pctiler/requirements-dev.txt
+++ b/pctiler/requirements-dev.txt
@@ -223,7 +223,7 @@ titiler-mosaic==0.18.3
     # via
     #   pctiler (pctiler/pyproject.toml)
     #   titiler-pgstac
-titiler-pgstac==1.3.0
+titiler-pgstac==1.3.1
     # via pctiler (pctiler/pyproject.toml)
 types-requests==2.32.4.20250809
     # via pctiler (pctiler/pyproject.toml)

--- a/pctiler/requirements-server.txt
+++ b/pctiler/requirements-server.txt
@@ -232,7 +232,7 @@ titiler-mosaic==0.18.3
     # via
     #   pctiler (pctiler/pyproject.toml)
     #   titiler-pgstac
-titiler-pgstac==1.3.0
+titiler-pgstac==1.3.1
     # via pctiler (pctiler/pyproject.toml)
 typing-extensions==4.14.1
     # via


### PR DESCRIPTION
## Description

The `search` model changed with PgSTAC 9.1 and will break titiler-pgstac application. This PR update titiler-pgstac dependency from 1.3.0 to 1.3.1 version which contains the fix 

Fixes #276 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

## Checklist:

Please delete options that are not relevant.

- [ ] I have performed a self-review
- [ ] Changelog has been updated
- [ ] Documentation has been updated
- [ ] Unit tests pass locally (./scripts/test)
- [ ] Code is linted and styled (./scripts/format)